### PR TITLE
feature(forms): expand existing form fields and add custom layouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@angular/platform-browser": "^19.2.0",
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/router": "^19.2.0",
+        "@types/luxon": "^3.6.2",
         "lucide-angular": "^0.507.0",
+        "luxon": "^3.6.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -5131,6 +5133,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -9945,6 +9953,15 @@
       "peerDependencies": {
         "@angular/common": "13.x - 19.x",
         "@angular/core": "13.x - 19.x"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
+    "@types/luxon": "^3.6.2",
     "lucide-angular": "^0.507.0",
+    "luxon": "^3.6.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,13 +1,1081 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+} from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { map } from 'rxjs';
 import { SignalFormComponent } from './signal-forms/components/renderers/signal-form/signal-form.component';
 import { FormFieldType } from './signal-forms/enums/form-field-type.enum';
 import { FormBuilder } from './signal-forms/helpers/form-builder';
 import {
+  type FormOption,
   type SignalFormContainer,
   type SignalFormFieldBuilderInput,
 } from './signal-forms/models/signal-form.model';
+import { TestApiService } from './signal-forms/services/test-http.service';
 import { SignalValidators } from './signal-forms/validators/signal-validators';
+
+const pokemonList: FormOption<{ name: string; typings: string[] }>[] = [
+  {
+    label: 'Bulbasaur',
+    value: {
+      name: 'Bulbasaur',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Ivysaur',
+    value: {
+      name: 'Ivysaur',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Venusaur',
+    value: {
+      name: 'Venusaur',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Charmander',
+    value: {
+      name: 'Charmander',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Charmeleon',
+    value: {
+      name: 'Charmeleon',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Charizard',
+    value: {
+      name: 'Charizard',
+      typings: ['Fire', 'Flying'],
+    },
+  },
+  {
+    label: 'Squirtle',
+    value: {
+      name: 'Squirtle',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Wartortle',
+    value: {
+      name: 'Wartortle',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Blastoise',
+    value: {
+      name: 'Blastoise',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Caterpie',
+    value: {
+      name: 'Caterpie',
+      typings: ['Bug'],
+    },
+  },
+  {
+    label: 'Metapod',
+    value: {
+      name: 'Metapod',
+      typings: ['Bug'],
+    },
+  },
+  {
+    label: 'Butterfree',
+    value: {
+      name: 'Butterfree',
+      typings: ['Bug', 'Flying'],
+    },
+  },
+  {
+    label: 'Weedle',
+    value: {
+      name: 'Weedle',
+      typings: ['Bug', 'Poison'],
+    },
+  },
+  {
+    label: 'Kakuna',
+    value: {
+      name: 'Kakuna',
+      typings: ['Bug', 'Poison'],
+    },
+  },
+  {
+    label: 'Beedrill',
+    value: {
+      name: 'Beedrill',
+      typings: ['Bug', 'Poison'],
+    },
+  },
+  {
+    label: 'Pidgey',
+    value: {
+      name: 'Pidgey',
+      typings: ['Normal', 'Flying'],
+    },
+  },
+  {
+    label: 'Pidgeotto',
+    value: {
+      name: 'Pidgeotto',
+      typings: ['Normal', 'Flying'],
+    },
+  },
+  {
+    label: 'Pidgeot',
+    value: {
+      name: 'Pidgeot',
+      typings: ['Normal', 'Flying'],
+    },
+  },
+  {
+    label: 'Rattata',
+    value: {
+      name: 'Rattata',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Raticate',
+    value: {
+      name: 'Raticate',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Spearow',
+    value: {
+      name: 'Spearow',
+      typings: ['Normal', 'Flying'],
+    },
+  },
+  {
+    label: 'Fearow',
+    value: {
+      name: 'Fearow',
+      typings: ['Normal', 'Flying'],
+    },
+  },
+  {
+    label: 'Ekans',
+    value: {
+      name: 'Ekans',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Arbok',
+    value: {
+      name: 'Arbok',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Pikachu',
+    value: {
+      name: 'Pikachu',
+      typings: ['Electric'],
+    },
+  },
+  {
+    label: 'Raichu',
+    value: {
+      name: 'Raichu',
+      typings: ['Electric'],
+    },
+  },
+  {
+    label: 'Sandshrew',
+    value: {
+      name: 'Sandshrew',
+      typings: ['Ground'],
+    },
+  },
+  {
+    label: 'Sandslash',
+    value: {
+      name: 'Sandslash',
+      typings: ['Ground'],
+    },
+  },
+  {
+    label: 'Nidoran♀',
+    value: {
+      name: 'Nidoran♀',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Nidorina',
+    value: {
+      name: 'Nidorina',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Nidoqueen',
+    value: {
+      name: 'Nidoqueen',
+      typings: ['Poison', 'Ground'],
+    },
+  },
+  {
+    label: 'Nidoran♂',
+    value: {
+      name: 'Nidoran♂',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Nidorino',
+    value: {
+      name: 'Nidorino',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Nidoking',
+    value: {
+      name: 'Nidoking',
+      typings: ['Poison', 'Ground'],
+    },
+  },
+  {
+    label: 'Clefairy',
+    value: {
+      name: 'Clefairy',
+      typings: ['Fairy'],
+    },
+  },
+  {
+    label: 'Clefable',
+    value: {
+      name: 'Clefable',
+      typings: ['Fairy'],
+    },
+  },
+  {
+    label: 'Vulpix',
+    value: {
+      name: 'Vulpix',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Ninetales',
+    value: {
+      name: 'Ninetales',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Jigglypuff',
+    value: {
+      name: 'Jigglypuff',
+      typings: ['Normal', 'Fairy'],
+    },
+  },
+  {
+    label: 'Wigglytuff',
+    value: {
+      name: 'Wigglytuff',
+      typings: ['Normal', 'Fairy'],
+    },
+  },
+  {
+    label: 'Zubat',
+    value: {
+      name: 'Zubat',
+      typings: ['Poison', 'Flying'],
+    },
+  },
+  {
+    label: 'Golbat',
+    value: {
+      name: 'Golbat',
+      typings: ['Poison', 'Flying'],
+    },
+  },
+  {
+    label: 'Oddish',
+    value: {
+      name: 'Oddish',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Gloom',
+    value: {
+      name: 'Gloom',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Vileplume',
+    value: {
+      name: 'Vileplume',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Paras',
+    value: {
+      name: 'Paras',
+      typings: ['Bug', 'Grass'],
+    },
+  },
+  {
+    label: 'Parasect',
+    value: {
+      name: 'Parasect',
+      typings: ['Bug', 'Grass'],
+    },
+  },
+  {
+    label: 'Venonat',
+    value: {
+      name: 'Venonat',
+      typings: ['Bug', 'Poison'],
+    },
+  },
+  {
+    label: 'Venomoth',
+    value: {
+      name: 'Venomoth',
+      typings: ['Bug', 'Poison'],
+    },
+  },
+  {
+    label: 'Diglett',
+    value: {
+      name: 'Diglett',
+      typings: ['Ground'],
+    },
+  },
+  {
+    label: 'Dugtrio',
+    value: {
+      name: 'Dugtrio',
+      typings: ['Ground'],
+    },
+  },
+  {
+    label: 'Meowth',
+    value: {
+      name: 'Meowth',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Persian',
+    value: {
+      name: 'Persian',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Psyduck',
+    value: {
+      name: 'Psyduck',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Golduck',
+    value: {
+      name: 'Golduck',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Mankey',
+    value: {
+      name: 'Mankey',
+      typings: ['Fighting'],
+    },
+  },
+  {
+    label: 'Primeape',
+    value: {
+      name: 'Primeape',
+      typings: ['Fighting'],
+    },
+  },
+  {
+    label: 'Growlithe',
+    value: {
+      name: 'Growlithe',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Arcanine',
+    value: {
+      name: 'Arcanine',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Poliwag',
+    value: {
+      name: 'Poliwag',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Poliwhirl',
+    value: {
+      name: 'Poliwhirl',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Poliwrath',
+    value: {
+      name: 'Poliwrath',
+      typings: ['Water', 'Fighting'],
+    },
+  },
+  {
+    label: 'Abra',
+    value: {
+      name: 'Abra',
+      typings: ['Psychic'],
+    },
+  },
+  {
+    label: 'Kadabra',
+    value: {
+      name: 'Kadabra',
+      typings: ['Psychic'],
+    },
+  },
+  {
+    label: 'Alakazam',
+    value: {
+      name: 'Alakazam',
+      typings: ['Psychic'],
+    },
+  },
+  {
+    label: 'Machop',
+    value: {
+      name: 'Machop',
+      typings: ['Fighting'],
+    },
+  },
+  {
+    label: 'Machoke',
+    value: {
+      name: 'Machoke',
+      typings: ['Fighting'],
+    },
+  },
+  {
+    label: 'Machamp',
+    value: {
+      name: 'Machamp',
+      typings: ['Fighting'],
+    },
+  },
+  {
+    label: 'Bellsprout',
+    value: {
+      name: 'Bellsprout',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Weepinbell',
+    value: {
+      name: 'Weepinbell',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Victreebel',
+    value: {
+      name: 'Victreebel',
+      typings: ['Grass', 'Poison'],
+    },
+  },
+  {
+    label: 'Tentacool',
+    value: {
+      name: 'Tentacool',
+      typings: ['Water', 'Poison'],
+    },
+  },
+  {
+    label: 'Tentacruel',
+    value: {
+      name: 'Tentacruel',
+      typings: ['Water', 'Poison'],
+    },
+  },
+  {
+    label: 'Geodude',
+    value: {
+      name: 'Geodude',
+      typings: ['Rock', 'Ground'],
+    },
+  },
+  {
+    label: 'Graveler',
+    value: {
+      name: 'Graveler',
+      typings: ['Rock', 'Ground'],
+    },
+  },
+  {
+    label: 'Golem',
+    value: {
+      name: 'Golem',
+      typings: ['Rock', 'Ground'],
+    },
+  },
+  {
+    label: 'Ponyta',
+    value: {
+      name: 'Ponyta',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Rapidash',
+    value: {
+      name: 'Rapidash',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Slowpoke',
+    value: {
+      name: 'Slowpoke',
+      typings: ['Water', 'Psychic'],
+    },
+  },
+  {
+    label: 'Slowbro',
+    value: {
+      name: 'Slowbro',
+      typings: ['Water', 'Psychic'],
+    },
+  },
+  {
+    label: 'Magnemite',
+    value: {
+      name: 'Magnemite',
+      typings: ['Electric', 'Steel'],
+    },
+  },
+  {
+    label: 'Magneton',
+    value: {
+      name: 'Magneton',
+      typings: ['Electric', 'Steel'],
+    },
+  },
+  {
+    label: 'Farfetch’d',
+    value: {
+      name: 'Farfetch’d',
+      typings: ['Normal', 'Flying'],
+    },
+  },
+  {
+    label: 'Doduo',
+    value: {
+      name: 'Doduo',
+      typings: ['Normal', 'Flying'],
+    },
+  },
+  {
+    label: 'Dodrio',
+    value: {
+      name: 'Dodrio',
+      typings: ['Normal', 'Flying'],
+    },
+  },
+  {
+    label: 'Seel',
+    value: {
+      name: 'Seel',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Dewgong',
+    value: {
+      name: 'Dewgong',
+      typings: ['Water', 'Ice'],
+    },
+  },
+  {
+    label: 'Grimer',
+    value: {
+      name: 'Grimer',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Muk',
+    value: {
+      name: 'Muk',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Shellder',
+    value: {
+      name: 'Shellder',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Cloyster',
+    value: {
+      name: 'Cloyster',
+      typings: ['Water', 'Ice'],
+    },
+  },
+  {
+    label: 'Gastly',
+    value: {
+      name: 'Gastly',
+      typings: ['Ghost', 'Poison'],
+    },
+  },
+  {
+    label: 'Haunter',
+    value: {
+      name: 'Haunter',
+      typings: ['Ghost', 'Poison'],
+    },
+  },
+  {
+    label: 'Gengar',
+    value: {
+      name: 'Gengar',
+      typings: ['Ghost', 'Poison'],
+    },
+  },
+  {
+    label: 'Onix',
+    value: {
+      name: 'Onix',
+      typings: ['Rock', 'Ground'],
+    },
+  },
+  {
+    label: 'Drowzee',
+    value: {
+      name: 'Drowzee',
+      typings: ['Psychic'],
+    },
+  },
+  {
+    label: 'Hypno',
+    value: {
+      name: 'Hypno',
+      typings: ['Psychic'],
+    },
+  },
+  {
+    label: 'Krabby',
+    value: {
+      name: 'Krabby',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Kingler',
+    value: {
+      name: 'Kingler',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Voltorb',
+    value: {
+      name: 'Voltorb',
+      typings: ['Electric'],
+    },
+  },
+  {
+    label: 'Electrode',
+    value: {
+      name: 'Electrode',
+      typings: ['Electric'],
+    },
+  },
+  {
+    label: 'Exeggcute',
+    value: {
+      name: 'Exeggcute',
+      typings: ['Grass', 'Psychic'],
+    },
+  },
+  {
+    label: 'Exeggutor',
+    value: {
+      name: 'Exeggutor',
+      typings: ['Grass', 'Psychic'],
+    },
+  },
+  {
+    label: 'Cubone',
+    value: {
+      name: 'Cubone',
+      typings: ['Ground'],
+    },
+  },
+  {
+    label: 'Marowak',
+    value: {
+      name: 'Marowak',
+      typings: ['Ground'],
+    },
+  },
+  {
+    label: 'Hitmonlee',
+    value: {
+      name: 'Hitmonlee',
+      typings: ['Fighting'],
+    },
+  },
+  {
+    label: 'Hitmonchan',
+    value: {
+      name: 'Hitmonchan',
+      typings: ['Fighting'],
+    },
+  },
+  {
+    label: 'Lickitung',
+    value: {
+      name: 'Lickitung',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Koffing',
+    value: {
+      name: 'Koffing',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Weezing',
+    value: {
+      name: 'Weezing',
+      typings: ['Poison'],
+    },
+  },
+  {
+    label: 'Rhyhorn',
+    value: {
+      name: 'Rhyhorn',
+      typings: ['Ground', 'Rock'],
+    },
+  },
+  {
+    label: 'Rhydon',
+    value: {
+      name: 'Rhydon',
+      typings: ['Ground', 'Rock'],
+    },
+  },
+  {
+    label: 'Chansey',
+    value: {
+      name: 'Chansey',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Tangela',
+    value: {
+      name: 'Tangela',
+      typings: ['Grass'],
+    },
+  },
+  {
+    label: 'Kangaskhan',
+    value: {
+      name: 'Kangaskhan',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Horsea',
+    value: {
+      name: 'Horsea',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Seadra',
+    value: {
+      name: 'Seadra',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Goldeen',
+    value: {
+      name: 'Goldeen',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Seaking',
+    value: {
+      name: 'Seaking',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Staryu',
+    value: {
+      name: 'Staryu',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Starmie',
+    value: {
+      name: 'Starmie',
+      typings: ['Water', 'Psychic'],
+    },
+  },
+  {
+    label: 'Mr. Mime',
+    value: {
+      name: 'Mr. Mime',
+      typings: ['Psychic', 'Fairy'],
+    },
+  },
+  {
+    label: 'Scyther',
+    value: {
+      name: 'Scyther',
+      typings: ['Bug', 'Flying'],
+    },
+  },
+  {
+    label: 'Jynx',
+    value: {
+      name: 'Jynx',
+      typings: ['Ice', 'Psychic'],
+    },
+  },
+  {
+    label: 'Electabuzz',
+    value: {
+      name: 'Electabuzz',
+      typings: ['Electric'],
+    },
+  },
+  {
+    label: 'Magmar',
+    value: {
+      name: 'Magmar',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Pinsir',
+    value: {
+      name: 'Pinsir',
+      typings: ['Bug'],
+    },
+  },
+  {
+    label: 'Tauros',
+    value: {
+      name: 'Tauros',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Magikarp',
+    value: {
+      name: 'Magikarp',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Gyarados',
+    value: {
+      name: 'Gyarados',
+      typings: ['Water', 'Flying'],
+    },
+  },
+  {
+    label: 'Lapras',
+    value: {
+      name: 'Lapras',
+      typings: ['Water', 'Ice'],
+    },
+  },
+  {
+    label: 'Ditto',
+    value: {
+      name: 'Ditto',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Eevee',
+    value: {
+      name: 'Eevee',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Vaporeon',
+    value: {
+      name: 'Vaporeon',
+      typings: ['Water'],
+    },
+  },
+  {
+    label: 'Jolteon',
+    value: {
+      name: 'Jolteon',
+      typings: ['Electric'],
+    },
+  },
+  {
+    label: 'Flareon',
+    value: {
+      name: 'Flareon',
+      typings: ['Fire'],
+    },
+  },
+  {
+    label: 'Porygon',
+    value: {
+      name: 'Porygon',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Omanyte',
+    value: {
+      name: 'Omanyte',
+      typings: ['Rock', 'Water'],
+    },
+  },
+  {
+    label: 'Omastar',
+    value: {
+      name: 'Omastar',
+      typings: ['Rock', 'Water'],
+    },
+  },
+  {
+    label: 'Kabuto',
+    value: {
+      name: 'Kabuto',
+      typings: ['Rock', 'Water'],
+    },
+  },
+  {
+    label: 'Kabutops',
+    value: {
+      name: 'Kabutops',
+      typings: ['Rock', 'Water'],
+    },
+  },
+  {
+    label: 'Aerodactyl',
+    value: {
+      name: 'Aerodactyl',
+      typings: ['Rock', 'Flying'],
+    },
+  },
+  {
+    label: 'Snorlax',
+    value: {
+      name: 'Snorlax',
+      typings: ['Normal'],
+    },
+  },
+  {
+    label: 'Articuno',
+    value: {
+      name: 'Articuno',
+      typings: ['Ice', 'Flying'],
+    },
+  },
+  {
+    label: 'Zapdos',
+    value: {
+      name: 'Zapdos',
+      typings: ['Electric', 'Flying'],
+    },
+  },
+  {
+    label: 'Moltres',
+    value: {
+      name: 'Moltres',
+      typings: ['Fire', 'Flying'],
+    },
+  },
+  {
+    label: 'Dratini',
+    value: {
+      name: 'Dratini',
+      typings: ['Dragon'],
+    },
+  },
+  {
+    label: 'Dragonair',
+    value: {
+      name: 'Dragonair',
+      typings: ['Dragon'],
+    },
+  },
+  {
+    label: 'Dragonite',
+    value: {
+      name: 'Dragonite',
+      typings: ['Dragon', 'Flying'],
+    },
+  },
+  {
+    label: 'Mewtwo',
+    value: {
+      name: 'Mewtwo',
+      typings: ['Psychic'],
+    },
+  },
+  {
+    label: 'Mew',
+    value: {
+      name: 'Mew',
+      typings: ['Psychic'],
+    },
+  },
+];
 
 export type Basket = {
   apples: number;
@@ -15,7 +1083,21 @@ export type Basket = {
   address: {
     line1: string;
     postcode: string;
-    country: string;
+    country: FormOption;
+    instructions: string;
+    expectedDate: Date;
+    postTo: FormOption[];
+    priority: string;
+    favouritePokemon: FormOption | null;
+    favouritePokemonTypes: FormOption[];
+  };
+  about: {
+    profilePicture: File | null;
+    bannerColor: string | null;
+    beastMode: boolean;
+    brightness: number;
+    rating: number;
+    phoneNumber: number | null;
   };
   applePrice: number;
   pearPrice: number;
@@ -25,57 +1107,15 @@ export type Basket = {
   total: number;
 };
 
+export type Country = {
+  name: {
+    common: string;
+  };
+  cca2: string;
+};
+
 export const OnlyPositiveValidator = (name: string) => (x: number) =>
   x < 0 ? `${name} only positive prices` : null;
-
-const addressForm: SignalFormFieldBuilderInput<Basket> = {
-  name: 'address',
-  heading: 'Delivery Address',
-  subheading: 'Where should we send your basket?',
-  hidden: (form) => form.getField('total').value() < 100,
-  fields: [
-    {
-      name: 'line1',
-      label: 'line 1',
-      type: FormFieldType.TEXT,
-      validators: [
-        (x, form) =>
-          !x.length && form.getField('postcode')?.value().length < 5
-            ? 'invalid address'
-            : null,
-      ],
-    },
-    {
-      name: 'postcode',
-      label: 'postcode',
-      type: FormFieldType.TEXT,
-    },
-    {
-      name: 'country',
-      label: 'Select Country',
-      type: FormFieldType.AUTOCOMPLETE,
-      loadOptions: (search: string) =>
-        fetch(`https://restcountries.com/v3.1/name/${search}`)
-          .then((res) => res.json())
-          .then((results) => {
-            if (!results.length) {
-              return [];
-            }
-            return results.map((country: any) => ({
-              label: country.name.common,
-              value: country.cca2,
-            }));
-          }),
-      config: {
-        debounceMs: 300,
-        minChars: 2,
-      },
-    },
-  ],
-  config: {
-    view: 'collapsable',
-  },
-};
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -87,13 +1127,36 @@ const addressForm: SignalFormFieldBuilderInput<Basket> = {
 export class AppComponent implements OnInit {
   public title = 'signal-template-forms';
   public form!: SignalFormContainer<Basket>;
+  public readonly testApiService = inject(TestApiService);
 
   public ngOnInit(): void {
-    const model = {
+    const model: Basket = {
       address: {
         line1: '46 newtown',
         postcode: 'sp3 6ny',
-        country: 'russia',
+        country: {
+          label: 'russia',
+          value: 'RUS',
+        },
+        favouritePokemon: null,
+        favouritePokemonTypes: [],
+        instructions: '',
+        expectedDate: new Date(),
+        postTo: [
+          {
+            label: 'Canada',
+            value: 'CAN',
+          },
+        ],
+        priority: 'HIGH',
+      },
+      about: {
+        profilePicture: null,
+        bannerColor: null,
+        beastMode: false,
+        brightness: 5,
+        rating: 3,
+        phoneNumber: null,
       },
       apples: 20,
       pears: 80,
@@ -105,11 +1168,259 @@ export class AppComponent implements OnInit {
       total: 101,
     };
 
+    const addressForm: SignalFormFieldBuilderInput<Basket> = {
+      name: 'address',
+      heading: 'Delivery Address',
+      subheading: 'Where should we send your basket?',
+      hidden: (form) => form.getField('total').value() < 100,
+      fields: [
+        {
+          name: 'line1',
+          label: 'line 1',
+          type: FormFieldType.TEXT,
+          validators: [
+            (x, form) =>
+              !x.length && form.getField('postcode')?.value().length < 5
+                ? 'invalid address'
+                : null,
+          ],
+        },
+        {
+          name: 'postcode',
+          label: 'postcode',
+          type: FormFieldType.TEXT,
+        },
+        {
+          name: 'country',
+          label: 'Select Country',
+          type: FormFieldType.AUTOCOMPLETE,
+          loadOptions: (search: string) =>
+            this.testApiService.getCountry(search).pipe(
+              map((countries) =>
+                countries.map((country) => ({
+                  label: country.name.common,
+                  value: country.cca2,
+                })),
+              ),
+            ),
+          config: {
+            debounceMs: 300,
+            minChars: 2,
+          },
+        },
+        {
+          name: 'favouritePokemonTypes',
+          label: 'Favourite Pokemon Types',
+          type: FormFieldType.MULTISELECT,
+          options: [
+            {
+              label: 'Normal',
+              value: 'normal',
+            },
+            {
+              label: 'Fire',
+              value: 'fire',
+            },
+            {
+              label: 'Water',
+              value: 'water',
+            },
+            {
+              label: 'Grass',
+              value: 'grass',
+            },
+            {
+              label: 'Electric',
+              value: 'electric',
+            },
+            {
+              label: 'Ice',
+              value: 'ice',
+            },
+            {
+              label: 'Fighting',
+              value: 'fighting',
+            },
+            {
+              label: 'Poison',
+              value: 'poison',
+            },
+            {
+              label: 'Ground',
+              value: 'ground',
+            },
+            {
+              label: 'Flying',
+              value: 'flying',
+            },
+            {
+              label: 'Psychic',
+              value: 'psychic',
+            },
+            {
+              label: 'Bug',
+              value: 'bug',
+            },
+            {
+              label: 'Rock',
+              value: 'rock',
+            },
+            {
+              label: 'Ghost',
+              value: 'ghost',
+            },
+            {
+              label: 'Dragon',
+              value: 'dragon',
+            },
+            {
+              label: 'Dark',
+              value: 'dark',
+            },
+            {
+              label: 'Steel',
+              value: 'steel',
+            },
+            {
+              label: 'Fairy',
+              value: 'fairy',
+            },
+          ],
+        },
+        {
+          name: 'favouritePokemon',
+          label: 'Favourite Pokemon',
+          type: FormFieldType.SELECT,
+          options: pokemonList,
+        },
+        {
+          name: 'instructions',
+          label: 'Delivery instructions',
+          type: FormFieldType.TEXTAREA,
+          config: {
+            placeholder: 'any delivery instructions we should know about?',
+          },
+        },
+        {
+          name: 'expectedDate',
+          label: 'expected date',
+          type: FormFieldType.DATETIME,
+        },
+        {
+          name: 'postTo',
+          label: 'post to',
+          type: FormFieldType.MULTISELECT,
+          options: [
+            {
+              value: 'CAN',
+              label: 'Canada',
+            },
+            {
+              value: 'RUS',
+              label: 'Russia',
+            },
+            {
+              value: 'AUS',
+              label: 'Australia',
+            },
+          ],
+        },
+        {
+          name: 'priority',
+          label: 'Priority',
+          type: FormFieldType.RADIO,
+          options: [
+            {
+              label: 'High',
+              value: 'HIGH',
+            },
+            {
+              label: 'Medium',
+              value: 'MEDIUM',
+            },
+            {
+              label: 'Low',
+              value: 'LOW',
+            },
+          ],
+        },
+      ],
+      config: {
+        view: 'collapsable',
+        layout: 'flex',
+      },
+    };
+
+    const aboutForm: SignalFormFieldBuilderInput<Basket> = {
+      heading: 'About you',
+      subheading: 'a few small things about you',
+      name: 'about',
+      fields: [
+        {
+          label: 'Profile Picture',
+          name: 'profilePicture',
+          type: FormFieldType.FILE,
+          config: {
+            maxSizeMb: 5,
+          },
+        },
+        {
+          name: 'bannerColor',
+          label: 'Banner Color',
+          type: FormFieldType.COLOR,
+          config: {
+            view: 'swatch',
+          },
+        },
+        {
+          name: 'phoneNumber',
+          label: 'Phone Number',
+          type: FormFieldType.MASKED,
+          config: {
+            mask: '(999) 999-9999',
+            placeholderChar: '_',
+            hint: 'Enter a 10-digit phone number',
+          },
+          validators: [
+            (val) => (!val ? 'this is required' : null),
+            // SignalValidators.minLength(14) // full mask length
+          ],
+        },
+        {
+          name: 'beastMode',
+          label: 'Beast Mode',
+          type: FormFieldType.SWITCH,
+        },
+        {
+          name: 'brightness',
+          label: 'Brightness',
+          type: FormFieldType.SLIDER,
+        },
+        {
+          name: 'rating',
+          label: 'rating',
+          type: FormFieldType.RATING,
+        },
+      ],
+      config: {
+        view: 'collapsable',
+        layout: 'grid-area',
+        gridArea: [
+          ['profilePicture', 'profilePicture', 'beastMode'],
+          ['profilePicture', 'profilePicture', '.'],
+          ['profilePicture', 'profilePicture', 'bannerColor'],
+          ['profilePicture', 'profilePicture', '.'],
+          ['brightness', 'phoneNumber', 'rating'],
+        ],
+      },
+    };
+
     this.form = FormBuilder.createForm<Basket>({
       title: 'Test Form',
       model,
       fields: [
         addressForm,
+        aboutForm,
         {
           name: 'apples',
           label: 'apples',
@@ -178,8 +1489,18 @@ export class AppComponent implements OnInit {
           ],
         },
       ],
-      config: {},
       onSave: (value) => this.save(value),
+      config: {
+        layout: 'grid-area',
+        gridArea: [
+          ['address', 'address', 'address'],
+          ['about', 'about', 'about'],
+          ['apples', 'applePrice', 'appleTotal'],
+          ['pears', 'pearPrice', 'pearTotal'],
+          ['isOrganic', 'isOrganic', 'isOrganic'],
+          ['total', 'total', 'total'],
+        ],
+      },
     });
   }
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
+import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { routes } from './app.routes';
 
@@ -9,5 +10,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideAnimations(),
+    provideHttpClient(),
   ],
 };

--- a/src/app/signal-forms/components/base/base-input/base-input.directive.ts
+++ b/src/app/signal-forms/components/base/base-input/base-input.directive.ts
@@ -1,6 +1,14 @@
-import { Directive, effect, input, model, signal } from '@angular/core';
+import {
+  Directive,
+  effect,
+  ElementRef,
+  inject,
+  input,
+  model,
+  signal,
+} from '@angular/core';
 import { FormFieldType } from '../../../enums/form-field-type.enum';
-import { ElementTypeForField } from '../../../models/signal-form.model';
+import { type ElementTypeForField } from '../../../models/signal-form.model';
 
 @Directive()
 export abstract class BaseInputDirective<
@@ -8,18 +16,20 @@ export abstract class BaseInputDirective<
   TValue,
   TFormConfig,
 > {
-  public label = input<string>('');
   public hint = input<string>('');
-  public error = input<string | null>();
   public disabled = input<boolean>(false);
   public config = input<TFormConfig | undefined>();
   public type = input<TFieldType>();
   public value = model.required<TValue | null>();
+  public error = model<string | null>();
   public touched = model.required<boolean>();
   public dirty = model.required<boolean>();
+  public name = input.required<string>();
 
   private initialValue = signal<TValue | null>(null);
   private hasCapturedInitial = signal(false);
+
+  private readonly elementRef = inject(ElementRef);
 
   constructor() {
     effect(() => {
@@ -52,6 +62,7 @@ export abstract class BaseInputDirective<
   }
 
   protected extractValue(element: ElementTypeForField<TFieldType>): TValue {
+    console.log(this.value(), element);
     if (element instanceof HTMLInputElement) {
       if (this.isCheckboxFieldType()) {
         return element.checked as TValue;

--- a/src/app/signal-forms/components/base/host-directive/signal-form-host.directive.ts
+++ b/src/app/signal-forms/components/base/host-directive/signal-form-host.directive.ts
@@ -1,0 +1,6 @@
+import { Directive, ViewContainerRef } from '@angular/core';
+
+@Directive({ selector: '[signalForHost]', standalone: true })
+export class SignalFormHostDirective {
+  constructor(public readonly viewContainerRef: ViewContainerRef) {}
+}

--- a/src/app/signal-forms/components/fields/fields.ts
+++ b/src/app/signal-forms/components/fields/fields.ts
@@ -1,0 +1,35 @@
+import { FormAutocompleteFieldComponent } from './form-autocomplete-field/form-autocomplete-field.component';
+import { FormCheckboxFieldComponent } from './form-checkbox-field/form-checkbox-field.component';
+import { FormColorFieldComponent } from './form-color-field/form-color-field.component';
+import { FormDatetimeFieldComponent } from './form-datetime-field/form-datetime-field.component';
+import { FormFileFieldComponent } from './form-file-field/form-file-field.component';
+import { FormMaskedFieldComponent } from './form-masked-field/form-masked-field.component';
+import { FormMultiselectFieldComponent } from './form-multiselect-field/form-multiselect-field.component';
+import { FormNumberFieldComponent } from './form-number-field/form-number-field.component';
+import { FormPasswordFieldComponent } from './form-password-field/form-password-field.component';
+import { FormRadioFieldComponent } from './form-radio-field/form-radio-field.component';
+import { FormRatingFieldComponent } from './form-rating-field/form-rating-field.component';
+import { FormSelectFieldComponent } from './form-select-field/form-select-field.component';
+import { FormSliderFieldComponent } from './form-slider-field/form-slider-field.component';
+import { FormSwitchFieldComponent } from './form-switch-field/form-switch-field.component';
+import { FormTextFieldComponent } from './form-text-field/form-text-field.component';
+import { FormTextareaFieldComponent } from './form-textarea-field/form-textarea-field.component';
+
+export const FormFields = [
+  FormAutocompleteFieldComponent,
+  FormCheckboxFieldComponent,
+  FormColorFieldComponent,
+  FormDatetimeFieldComponent,
+  FormFileFieldComponent,
+  FormMaskedFieldComponent,
+  FormMultiselectFieldComponent,
+  FormNumberFieldComponent,
+  FormPasswordFieldComponent,
+  FormRadioFieldComponent,
+  FormRatingFieldComponent,
+  FormSelectFieldComponent,
+  FormSliderFieldComponent,
+  FormSwitchFieldComponent,
+  FormTextFieldComponent,
+  FormTextareaFieldComponent,
+];

--- a/src/app/signal-forms/components/fields/form-autocomplete-field/form-autocomplete-field.component.html
+++ b/src/app/signal-forms/components/fields/form-autocomplete-field/form-autocomplete-field.component.html
@@ -1,20 +1,16 @@
-<div class="autocomplete-wrapper">
+<div
+  class="form-input-wrapper"
+  [ngClass]="showDropdown() ? 'dropdown-open' : ''"
+  #autocompleteInputWrapper
+>
   <input
+    class="form-input"
     type="text"
+    [attr.name]="name()"
     [value]="value()?.label ?? ''"
     (input)="search.set($event.target.value)"
     (focus)="showDropdown.set(true)"
     (change)="handleBlur()"
     (blur)="handleBlur()"
   />
-
-  @if (showDropdown() && options().length) {
-    <ul class="autocomplete-dropdown">
-      @for (option of options(); track option.value) {
-        <li (mousedown)="onSelect(option)">
-          {{ option.label }}
-        </li>
-      }
-    </ul>
-  }
 </div>

--- a/src/app/signal-forms/components/fields/form-autocomplete-field/form-autocomplete-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-autocomplete-field/form-autocomplete-field.component.scss
@@ -1,29 +1,28 @@
-.autocomplete-wrapper {
-  position: relative;
-  input {
-    width: 100%;
+.autocomplete-dropdown {
+  position: absolute;
+  z-index: 10;
+  background: white;
+  border: 1px solid #ccc;
+  width: 100%;
+  max-height: 200px;
+  overflow-y: auto;
+  list-style: none;
+  padding: unset;
+  margin: 0;
+  top: 38px;
+  flex-direction: column;
+
+  li {
     padding: 0.5rem;
-  }
+    cursor: pointer;
 
-  .autocomplete-dropdown {
-    position: absolute;
-    z-index: 10;
-    background: white;
-    border: 1px solid #ccc;
-    width: 100%;
-    max-height: 200px;
-    overflow-y: auto;
-    list-style: none;
-    padding: unset;
-    margin: 0;
-
-    li {
-      padding: 0.5rem;
-      cursor: pointer;
-
-      &:hover {
-        background: #f4f4f4;
-      }
+    &:hover {
+      background: #f4f4f4;
     }
   }
+}
+
+.dropdown-open {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }

--- a/src/app/signal-forms/components/fields/form-autocomplete-field/form-autocomplete-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-autocomplete-field/form-autocomplete-field.component.ts
@@ -3,28 +3,34 @@ import {
   Component,
   DestroyRef,
   effect,
+  ElementRef,
   inject,
   Injector,
   input,
+  Optional,
   signal,
+  viewChild,
+  ViewContainerRef,
 } from '@angular/core';
 
+import { NgClass } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { BaseInputDirective } from '@base/base-input/base-input.directive';
+import { SignalFormHostDirective } from '@base/host-directive/signal-form-host.directive';
+import { FormFieldType } from '@enums/form-field-type.enum';
+import { type AutocompleteFieldConfig } from '@models/signal-field-configs.model';
+import { type FormOption, type LoadOptionsFn } from '@models/signal-form.model';
+import { FormDropdownService } from '@services/form-dropdown.service';
 import { from, isObservable } from 'rxjs';
-import { FormFieldType } from '../../../enums/form-field-type.enum';
-import {
-  AutocompleteFieldConfig,
-  FormOption,
-  LoadOptionsFn,
-} from '../../../models/signal-form.model';
-import { BaseInputDirective } from '../../base/base-input/base-input.directive';
 
 @Component({
-  selector: 'app-form-autocomplete-field',
+  selector: 'signal-form-autocomplete-field',
   standalone: true,
+  imports: [NgClass],
   templateUrl: './form-autocomplete-field.component.html',
   styleUrl: './form-autocomplete-field.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [SignalFormHostDirective],
 })
 export class FormAutocompleteFieldComponent extends BaseInputDirective<
   FormFieldType.AUTOCOMPLETE,
@@ -32,6 +38,9 @@ export class FormAutocompleteFieldComponent extends BaseInputDirective<
   AutocompleteFieldConfig
 > {
   public loadOptions = input.required<LoadOptionsFn>();
+  public inputRef = viewChild<ElementRef<HTMLElement>>(
+    'autocompleteInputWrapper',
+  );
 
   protected search = signal('');
   protected options = signal<FormOption[]>([]);
@@ -40,9 +49,49 @@ export class FormAutocompleteFieldComponent extends BaseInputDirective<
   private destroyRef = inject(DestroyRef);
   private injector = inject(Injector);
 
-  constructor() {
+  private readonly dropdownService = inject(FormDropdownService);
+
+  constructor(
+    @Optional()
+    private readonly signalFormHostDirective: SignalFormHostDirective,
+  ) {
     super();
     this.searchQueryChangeEffect();
+    this.optionsOverlayEffect();
+  }
+
+  private get hostViewContainerRef(): ViewContainerRef | null {
+    return this.signalFormHostDirective?.viewContainerRef ?? null;
+  }
+
+  private optionsOverlayEffect(): void {
+    effect(
+      () => {
+        if (
+          !this.showDropdown() ||
+          !this.options().length ||
+          !this.inputRef()
+        ) {
+          return;
+        }
+
+        this.dropdownService.openDropdown<FormOption>({
+          options: this.options(),
+          reference: this.inputRef()!.nativeElement,
+          viewContainerRef: this.hostViewContainerRef!,
+          onSelect: (option) => {
+            if (option) {
+              this.setValue(option);
+            }
+            this.touched.set(true);
+            this.showDropdown.set(false);
+            this.dropdownService.destroyDropdown();
+          },
+          multiselect: false,
+        });
+      },
+      { injector: this.injector },
+    );
   }
 
   public onSelect(option: FormOption) {

--- a/src/app/signal-forms/components/fields/form-checkbox-field/form-checkbox-field.component.html
+++ b/src/app/signal-forms/components/fields/form-checkbox-field/form-checkbox-field.component.html
@@ -1,17 +1,12 @@
-<div class="flex flex-col gap-1">
-  <label class="flex items-center space-x-2">
-    <input
-      type="checkbox"
-      class="checkbox"
-      [disabled]="disabled()"
-      [checked]="value()"
-      (change)="handleInput($event)"
-      (blur)="handleBlur()"
-    />
-    <span>{{ label() }}</span>
-  </label>
-
-  @if (error()) {
-    <span class="text-sm text-red-500">{{ error() }}</span>
-  }
-</div>
+<label class="form-checkbox-wrapper">
+  <input
+    type="checkbox"
+    [attr.name]="name()"
+    class="checkbox"
+    [disabled]="disabled()"
+    [checked]="value()"
+    (change)="handleInput($event)"
+    (blur)="handleBlur()"
+  />
+  <span class="form-checkbox-label">{{ label() }}</span>
+</label>

--- a/src/app/signal-forms/components/fields/form-checkbox-field/form-checkbox-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-checkbox-field/form-checkbox-field.component.scss
@@ -1,0 +1,12 @@
+.form-checkbox {
+  &-label {
+    font-size: 12px;
+  }
+
+  &-wrapper {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 4px;
+  }
+}

--- a/src/app/signal-forms/components/fields/form-checkbox-field/form-checkbox-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-checkbox-field/form-checkbox-field.component.ts
@@ -1,12 +1,13 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FormFieldType } from '../../../enums/form-field-type.enum';
-import { CheckboxFieldConfig } from '../../../models/signal-form.model';
+import { type CheckboxFieldConfig } from '../../../models/signal-field-configs.model';
 import { BaseInputDirective } from '../../base/base-input/base-input.directive';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  selector: 'app-form-checkbox-field',
+  selector: 'signal-form-checkbox-field',
   standalone: true,
+  styleUrl: './form-checkbox-field.component.scss',
   templateUrl: './form-checkbox-field.component.html',
 })
 export class FormCheckboxFieldComponent extends BaseInputDirective<
@@ -14,6 +15,8 @@ export class FormCheckboxFieldComponent extends BaseInputDirective<
   boolean,
   CheckboxFieldConfig
 > {
+  public label = input<string>('');
+
   protected override extractValue(element: HTMLInputElement): boolean {
     return element.checked;
   }

--- a/src/app/signal-forms/components/fields/form-chip-list-field/form-chip-list-field.component.html
+++ b/src/app/signal-forms/components/fields/form-chip-list-field/form-chip-list-field.component.html
@@ -1,0 +1,11 @@
+<div class="chip-option-list" [attr.name]="name()">
+  @for (option of options(); track option.value) {
+    <div
+      class="chip-option"
+      [class.selected]="isSelected(option)"
+      (click)="toggleOption(option)"
+    >
+      {{ option.label }}
+    </div>
+  }
+</div>

--- a/src/app/signal-forms/components/fields/form-chip-list-field/form-chip-list-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-chip-list-field/form-chip-list-field.component.scss
@@ -1,0 +1,20 @@
+.chip-option-list {
+  display: flex;
+  flex: 0 auto;
+  gap: 0.5rem;
+
+  .chip-option {
+    padding: 4px 10px;
+    border-radius: 8px;
+    border: 1px solid #ccc;
+    background-color: #f5f5f5;
+    cursor: pointer;
+    font-size: 0.875rem;
+
+    &.selected {
+      background-color: #00acc1;
+      color: white;
+      border-color: transparent;
+    }
+  }
+}

--- a/src/app/signal-forms/components/fields/form-chip-list-field/form-chip-list-field.component.spec.ts
+++ b/src/app/signal-forms/components/fields/form-chip-list-field/form-chip-list-field.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormChipListFieldComponent } from './form-chip-list-field.component';
+
+describe('FormChipListFieldComponent', () => {
+  let component: FormChipListFieldComponent;
+  let fixture: ComponentFixture<FormChipListFieldComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormChipListFieldComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FormChipListFieldComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/signal-forms/components/fields/form-chip-list-field/form-chip-list-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-chip-list-field/form-chip-list-field.component.ts
@@ -1,0 +1,35 @@
+import { Component, computed, input } from '@angular/core';
+import { FormFieldType } from '../../../enums/form-field-type.enum';
+import { ChipListFieldConfig } from '../../../models/signal-field-configs.model';
+import { FormOption } from '../../../models/signal-form.model';
+import { BaseInputDirective } from '../../base/base-input/base-input.directive';
+
+@Component({
+  selector: 'app-form-chip-list-field',
+  imports: [],
+  templateUrl: './form-chip-list-field.component.html',
+  styleUrl: './form-chip-list-field.component.scss',
+})
+export class FormChipListFieldComponent extends BaseInputDirective<
+  FormFieldType.CHIPLIST,
+  FormOption[],
+  ChipListFieldConfig
+> {
+  public options = input.required<FormOption[]>();
+
+  public selectedValues = computed(() => this.value() ?? []);
+
+  public isSelected = (option: FormOption): boolean =>
+    !!this.selectedValues().find((val) => val.value === option.value);
+
+  public toggleOption(option: FormOption): void {
+    const current = this.selectedValues();
+    const updated = this.isSelected(option)
+      ? current.filter((val) => val.value !== option.value)
+      : [...current, option];
+
+    this.setValue(updated);
+    this.touched.set(true);
+    this.dirty.set(true);
+  }
+}

--- a/src/app/signal-forms/components/fields/form-color-field/form-color-field.component.html
+++ b/src/app/signal-forms/components/fields/form-color-field/form-color-field.component.html
@@ -1,0 +1,36 @@
+<div class="color-field-wrapper">
+  @if (isSwatchOnly()) {
+    <label class="color-swatch">
+      <input
+        type="color"
+        [attr.name]="name()"
+        [value]="currentColor()"
+        [disabled]="disabled()"
+        (input)="onColorInputChange($event)"
+        (blur)="handleBlur()"
+      />
+      <span class="swatch-display" [style.background]="currentColor()"></span>
+    </label>
+  } @else {
+    <div class="color-picker-full">
+      <input
+        type="color"
+        [attr.name]="name()"
+        class="color-input"
+        [value]="currentColor()"
+        [disabled]="disabled()"
+        (input)="onColorInputChange($event)"
+        (blur)="handleBlur()"
+      />
+
+      <input
+        type="text"
+        class="hex-input"
+        [value]="inputValue()"
+        [disabled]="disabled()"
+        (input)="onTextInputChange($event.target.value)"
+        (blur)="handleBlur()"
+      />
+    </div>
+  }
+</div>

--- a/src/app/signal-forms/components/fields/form-color-field/form-color-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-color-field/form-color-field.component.scss
@@ -1,0 +1,52 @@
+.color-field-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.color-swatch {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  input[type="color"] {
+    opacity: 0;
+    width: 40px;
+    height: 40px;
+    position: absolute;
+    left: 0;
+    top: 0;
+    cursor: pointer;
+  }
+
+  .swatch-display {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 2px solid #ccc;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+  }
+}
+
+.color-picker-full {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  .color-input {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: none;
+    background: none;
+  }
+
+  .hex-input {
+    flex: 1;
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    font-family: monospace;
+  }
+}

--- a/src/app/signal-forms/components/fields/form-color-field/form-color-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-color-field/form-color-field.component.ts
@@ -1,0 +1,51 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+} from '@angular/core';
+import { ColorFieldConfig } from '@models/signal-field-configs.model';
+import { FormFieldType } from '../../../enums/form-field-type.enum';
+import { BaseInputDirective } from '../../base/base-input/base-input.directive';
+
+@Component({
+  selector: 'signal-form-color-field',
+  standalone: true,
+  templateUrl: './form-color-field.component.html',
+  styleUrl: './form-color-field.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormColorFieldComponent extends BaseInputDirective<
+  FormFieldType.COLOR,
+  string,
+  ColorFieldConfig
+> {
+  private fallbackColor = '#000000';
+
+  protected currentColor = computed(() => this.value() ?? this.fallbackColor);
+  protected isSwatchOnly = computed(() => {
+    return this.config()?.view === 'swatch';
+  });
+
+  protected inputValue = computed(() => this.value() ?? this.fallbackColor);
+
+  constructor() {
+    super();
+
+    effect(() => {
+      if (!CSS.supports('color', this.inputValue())) {
+        console.log(this.inputValue());
+        this.error.set('unsupported Color value!');
+      }
+    });
+  }
+
+  protected onTextInputChange(val: string): void {
+    this.setValue(val);
+  }
+
+  protected onColorInputChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.setValue(value);
+  }
+}

--- a/src/app/signal-forms/components/fields/form-datetime-field/form-datetime-field.component.html
+++ b/src/app/signal-forms/components/fields/form-datetime-field/form-datetime-field.component.html
@@ -1,1 +1,9 @@
-<p>form-datetime-field works!</p>
+<input
+  [attr.name]="name()"
+  class="form-input"
+  type="datetime-local"
+  [value]="formattedValue()"
+  [disabled]="disabled()"
+  (input)="handleInput($event)"
+  (blur)="handleBlur()"
+/>

--- a/src/app/signal-forms/components/fields/form-datetime-field/form-datetime-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-datetime-field/form-datetime-field.component.ts
@@ -1,10 +1,12 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { DateTime } from 'luxon';
 import { FormFieldType } from '../../../enums/form-field-type.enum';
-import { DateTimeFieldConfig } from '../../../models/signal-form.model';
+import { DateTimeFieldConfig } from '../../../models/signal-field-configs.model';
 import { BaseInputDirective } from '../../base/base-input/base-input.directive';
 
 @Component({
-  selector: 'app-form-datetime-field',
+  selector: 'signal-form-datetime-field',
+  standalone: true,
   imports: [],
   templateUrl: './form-datetime-field.component.html',
   styleUrl: './form-datetime-field.component.scss',
@@ -14,4 +16,14 @@ export class FormDatetimeFieldComponent extends BaseInputDirective<
   FormFieldType.DATETIME,
   Date,
   DateTimeFieldConfig
-> {}
+> {
+  protected formattedValue = computed(() => {
+    const date = this.value();
+    const format = this.config()?.format ?? "yyyy-LL-dd'T'HH:mm";
+    return date ? DateTime.fromJSDate(date).toFormat(format) : '';
+  });
+
+  override extractValue(el: HTMLInputElement): Date {
+    return new Date(el.value);
+  }
+}

--- a/src/app/signal-forms/components/fields/form-file-field/form-file-field.component.html
+++ b/src/app/signal-forms/components/fields/form-file-field/form-file-field.component.html
@@ -1,0 +1,29 @@
+<div
+  class="file-upload-dropzone"
+  [class.dragging]="isDragging()"
+  (drop)="onDrop($event)"
+  (dragover)="onDragOver($event)"
+  (dragleave)="onDragLeave()"
+  (click)="openFileDialog(fileInput)"
+>
+  <div class="upload-icon">☁️</div>
+  <div class="upload-text">
+    {{ config()?.uploadText || "Click or drag a file to upload" }}
+  </div>
+  @if (value()) {
+    <div class="uploaded-file">{{ value()?.name }}</div>
+  }
+  <input
+    #fileInput
+    [attr.name]="name()"
+    type="file"
+    [disabled]="disabled()"
+    [accept]="config()?.accept?.join(',')"
+    (change)="onFileChange($event)"
+  />
+  @if (uploadProgress() !== null) {
+    <div class="progress-bar">
+      <div class="progress" [style.width.%]="uploadProgress()"></div>
+    </div>
+  }
+</div>

--- a/src/app/signal-forms/components/fields/form-file-field/form-file-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-file-field/form-file-field.component.scss
@@ -1,0 +1,46 @@
+.file-upload-dropzone {
+  border: 2px dashed #cbd5e0;
+  padding: 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+
+  &.dragging {
+    border-color: #3182ce;
+    background-color: #ebf8ff;
+  }
+
+  .upload-icon {
+    font-size: 32px;
+    margin-bottom: 8px;
+  }
+
+  .upload-text {
+    font-size: 14px;
+    color: #4a5568;
+    margin-bottom: 8px;
+  }
+
+  .uploaded-file {
+    font-size: 13px;
+    color: #2d3748;
+    margin-top: 4px;
+  }
+
+  .progress-bar {
+    height: 6px;
+    width: 100%;
+    background: #e2e8f0;
+    border-radius: 4px;
+    margin-top: 10px;
+    overflow: hidden;
+
+    .progress {
+      height: 100%;
+      background: #3182ce;
+      transition: width 0.3s ease;
+    }
+  }
+}

--- a/src/app/signal-forms/components/fields/form-file-field/form-file-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-file-field/form-file-field.component.ts
@@ -1,0 +1,89 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+} from '@angular/core';
+import { BaseInputDirective } from '@base/base-input/base-input.directive';
+import { SignalFormHostDirective } from '@base/host-directive/signal-form-host.directive';
+import { FormFieldType } from '@enums/form-field-type.enum';
+import { FileFieldConfig } from '@models/signal-field-configs.model';
+
+@Component({
+  selector: 'signal-form-file-field',
+  standalone: true,
+  templateUrl: './form-file-field.component.html',
+  styleUrl: './form-file-field.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [SignalFormHostDirective],
+})
+export class FormFileFieldComponent extends BaseInputDirective<
+  FormFieldType.FILE,
+  File | null,
+  FileFieldConfig
+> {
+  protected isDragging = signal(false);
+  protected uploadProgress = signal<number | null>(null);
+
+  private maxSizeBytes = computed(
+    () => (this.config()?.maxSizeMb ?? 5) * 1024 * 1024,
+  );
+
+  public onFileChange(event: File): void {
+    console.log(event);
+
+    const file = (event as any).target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const maxSize = this.maxSizeBytes();
+    if (file.size > maxSize) {
+      this.error.set(
+        `File exceeds max size of ${this.config()?.maxSizeMb ?? 5}MB`,
+      );
+      return;
+    }
+
+    this.setValue(file);
+    this.uploadProgress.set(0);
+    this.simulateUpload(file);
+    this.touched.set(true);
+  }
+
+  private simulateUpload(file: File) {
+    let progress = 0;
+    const interval = setInterval(() => {
+      progress += 10;
+      this.uploadProgress.set(progress);
+
+      if (progress >= 100) {
+        clearInterval(interval);
+        this.uploadProgress.set(null); // Upload complete
+      }
+    }, 100);
+  }
+
+  public onDrop(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragging.set(false);
+
+    const file = event.dataTransfer?.files?.[0];
+    if (file) {
+      this.onFileChange(file);
+    }
+  }
+
+  public onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragging.set(true);
+  }
+
+  public onDragLeave(): void {
+    this.isDragging.set(false);
+  }
+
+  public openFileDialog(input: HTMLInputElement): void {
+    input.click();
+  }
+}

--- a/src/app/signal-forms/components/fields/form-masked-field/form-masked-field.component.html
+++ b/src/app/signal-forms/components/fields/form-masked-field/form-masked-field.component.html
@@ -1,0 +1,14 @@
+<div class="form-input-wrapper">
+  <input
+    #maskedInput
+    [attr.name]="name()"
+    type="text"
+    class="form-input"
+    [placeholder]="config()?.placeholder"
+    [disabled]="disabled()"
+    [value]="value()"
+    (keydown)="onKeyDown($event)"
+    (input)="onInput($event)"
+    (blur)="handleBlur()"
+  />
+</div>

--- a/src/app/signal-forms/components/fields/form-masked-field/form-masked-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-masked-field/form-masked-field.component.ts
@@ -1,0 +1,124 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  viewChild,
+} from '@angular/core';
+import { MaskedFieldConfig } from '@models/signal-field-configs.model';
+import { MaskParser } from 'app/signal-forms/helpers/mask-parser';
+import { FormFieldType } from '../../../enums/form-field-type.enum';
+import { BaseInputDirective } from '../../base/base-input/base-input.directive';
+
+@Component({
+  selector: 'signal-form-masked-field',
+  standalone: true,
+  templateUrl: './form-masked-field.component.html',
+  styleUrl: './form-masked-field.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormMaskedFieldComponent extends BaseInputDirective<
+  FormFieldType.MASKED,
+  string,
+  MaskedFieldConfig
+> {
+  private inputRef = viewChild('maskedInput', { read: ElementRef });
+
+  private readonly mask = computed(() => this.config()?.mask ?? '');
+  private lastCaretPos = 0;
+
+  constructor() {
+    super();
+    this.initializeEffect();
+  }
+
+  private initializeEffect() {
+    effect(() => {
+      if (!this.mask() || this.value()) return;
+
+      const initial = MaskParser.format('', this.mask());
+      this.setValue(initial);
+    });
+  }
+
+  public onInput(event: Event): void {
+    const el = this.inputRef()?.nativeElement;
+    const rawValue = el.value;
+    const caret = el.selectionStart ?? 0;
+
+    const masked = MaskParser.format(rawValue, this.mask());
+    this.setValue(masked);
+
+    this.dirty.set(true);
+    this.lastCaretPos = MaskParser.getNextEditableIndex(this.mask(), caret);
+    this.moveCaret(this.lastCaretPos);
+  }
+
+  public onKeyDown(event: KeyboardEvent): void {
+    const el = this.inputRef()?.nativeElement;
+    const start = el.selectionStart ?? 0;
+    const end = el.selectionEnd ?? start;
+    const key = event.key;
+
+    const hasSelection = end > start;
+
+    if (key === 'Backspace' || key === 'Delete') {
+      event.preventDefault();
+
+      const mask = this.mask();
+      let updated = this.value() ?? '';
+
+      const editableIndices = MaskParser.getEditableIndices(mask);
+
+      const range = hasSelection ? [start, end] : [start - 1, start];
+      const charsToClear = editableIndices.filter(
+        (i) => i >= range[0] && i < range[1],
+      );
+
+      for (const idx of charsToClear) {
+        updated = updated.substring(0, idx) + '_' + updated.substring(idx + 1);
+      }
+
+      this.setValue(updated);
+      this.dirty.set(true);
+
+      const caretAfter = MaskParser.getNextEditableIndex(mask, range[0]);
+      this.moveCaret(caretAfter);
+    }
+
+    // Prevent invalid char input
+    if (key.length === 1 && !this.isValidChar(key, start)) {
+      event.preventDefault();
+    }
+  }
+
+  private isValidChar(char: string, pos: number): boolean {
+    const defs = MaskParser.DEFAULT_MASK_DEFINITION;
+    const token = this.mask()[pos];
+    const def = defs[token as keyof typeof defs];
+    return !!def?.test(char);
+  }
+
+  private removeCharAt(pos: number): void {
+    const current = this.value() ?? '';
+    const maskChar = this.mask()[pos];
+    if (
+      !MaskParser.DEFAULT_MASK_DEFINITION[
+        maskChar as keyof typeof MaskParser.DEFAULT_MASK_DEFINITION
+      ]
+    )
+      return;
+
+    const updated =
+      current.substring(0, pos) + '_' + current.substring(pos + 1);
+    this.setValue(updated);
+    this.dirty.set(true);
+  }
+
+  private moveCaret(pos: number): void {
+    requestAnimationFrame(() => {
+      this.inputRef()?.nativeElement.setSelectionRange(pos, pos);
+    });
+  }
+}

--- a/src/app/signal-forms/components/fields/form-multiselect-field/form-multiselect-field.component.html
+++ b/src/app/signal-forms/components/fields/form-multiselect-field/form-multiselect-field.component.html
@@ -1,0 +1,24 @@
+<div
+  class="multi-select-wrapper"
+  #multiselectWrapper
+  tabindex="0"
+  [attr.name]="name()"
+  (keydown.enter)="toggleDropdown()"
+>
+  <div class="chip-list" (click)="toggleDropdown()">
+    @for (item of value() ?? []; track item.value) {
+      <div class="chip">
+        {{ item.label }}
+        <button type="button" class="remove-btn" (click)="removeChip(item)">
+          ×
+        </button>
+      </div>
+    }
+  </div>
+
+  @if (!value()?.length && config()?.placeholder) {
+    <div class="placeholder">
+      {{ config()?.placeholder }}
+    </div>
+  }
+</div>

--- a/src/app/signal-forms/components/fields/form-multiselect-field/form-multiselect-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-multiselect-field/form-multiselect-field.component.scss
@@ -1,0 +1,36 @@
+.multi-select-wrapper {
+  border: 1px solid #ccc;
+  padding: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  cursor: pointer;
+  min-height: 40px;
+
+  .chip {
+    background: #e0f7fa;
+    border-radius: 16px;
+    padding: 2px 8px;
+    margin: 2px;
+    display: flex;
+    align-items: center;
+
+    &-list {
+      width: 100%;
+      flex: 0 0 auto;
+      display: flex;
+      flex-wrap: wrap;
+    }
+
+    .remove-btn {
+      border: none;
+      background: none;
+      margin-left: 4px;
+      cursor: pointer;
+    }
+  }
+
+  .placeholder {
+    opacity: 0.5;
+    margin: 4px;
+  }
+}

--- a/src/app/signal-forms/components/fields/form-multiselect-field/form-multiselect-field.component.spec.ts
+++ b/src/app/signal-forms/components/fields/form-multiselect-field/form-multiselect-field.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormMultiselectFieldComponent } from './form-multiselect-field.component';
+
+describe('FormMultiselectFieldComponent', () => {
+  let component: FormMultiselectFieldComponent;
+  let fixture: ComponentFixture<FormMultiselectFieldComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormMultiselectFieldComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FormMultiselectFieldComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/signal-forms/components/fields/form-multiselect-field/form-multiselect-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-multiselect-field/form-multiselect-field.component.ts
@@ -1,0 +1,86 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  Injector,
+  input,
+  signal,
+} from '@angular/core';
+import { MultiSelectFieldConfig } from 'app/signal-forms/models/signal-field-configs.model';
+import { FormFieldType } from '../../../enums/form-field-type.enum';
+import { FormOption } from '../../../models/signal-form.model';
+import { FormDropdownService } from '../../../services/form-dropdown.service';
+import { BaseInputDirective } from '../../base/base-input/base-input.directive';
+import { SignalFormHostDirective } from '../../base/host-directive/signal-form-host.directive';
+
+@Component({
+  selector: 'signal-form-multiselect-field',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './form-multiselect-field.component.html',
+  styleUrl: './form-multiselect-field.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  hostDirectives: [SignalFormHostDirective],
+})
+export class FormMultiselectFieldComponent extends BaseInputDirective<
+  FormFieldType.MULTISELECT,
+  FormOption[],
+  MultiSelectFieldConfig
+> {
+  public options = input<FormOption[]>([]);
+  protected showDropdown = signal(false);
+
+  private readonly dropdownService = inject(FormDropdownService);
+  private readonly host = inject(SignalFormHostDirective);
+  private readonly injector = inject(Injector);
+
+  constructor() {
+    super();
+    this.dropdownOverlayEffect();
+  }
+
+  private dropdownOverlayEffect(): void {
+    effect(
+      () => {
+        if (!this.showDropdown()) {
+          return;
+        }
+
+        const reference = this.host.viewContainerRef.element.nativeElement;
+
+        this.dropdownService.openDropdown<FormOption[]>({
+          options: this.options(),
+          reference,
+          viewContainerRef: this.host.viewContainerRef,
+          multiselect: true,
+          initialSelection: this.value(),
+          onSelect: (selected) => {
+            if (Array.isArray(selected)) {
+              this.setValue(selected);
+              this.touched.set(true);
+            }
+          },
+          onClose: () => {
+            this.showDropdown.set(false);
+          },
+        });
+      },
+      {
+        injector: this.injector,
+      },
+    );
+  }
+
+  public removeChip(option: FormOption): void {
+    this.value.update((vals) =>
+      (vals ?? []).filter((o) => o.value !== option.value),
+    );
+    this.touched.set(true);
+  }
+
+  public toggleDropdown(): void {
+    this.showDropdown.update((show) => !show);
+  }
+}

--- a/src/app/signal-forms/components/fields/form-number-field/form-number-field.component.html
+++ b/src/app/signal-forms/components/fields/form-number-field/form-number-field.component.html
@@ -2,12 +2,13 @@
   <input
     type="number"
     class="form-input"
+    [attr.name]="name()"
     [placeholder]="config()?.placeholder"
     [disabled]="disabled()"
+    [step]="config()?.precision ?? 1"
     [(value)]="value"
     (input)="handleInput($event)"
     (change)="handleBlur()"
     (blur)="handleBlur()"
-    [step]="config()?.precision ?? 0.01"
   />
 </div>

--- a/src/app/signal-forms/components/fields/form-number-field/form-number-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-number-field/form-number-field.component.ts
@@ -1,11 +1,11 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormFieldType } from '../../../enums/form-field-type.enum';
-import { NumberFieldConfig } from '../../../models/signal-form.model';
+import { type NumberFieldConfig } from '../../../models/signal-field-configs.model';
 import { BaseInputDirective } from '../../base/base-input/base-input.directive';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  selector: 'app-form-number-field',
+  selector: 'signal-form-number-field',
   standalone: true,
   templateUrl: './form-number-field.component.html',
 })

--- a/src/app/signal-forms/components/fields/form-password-field/form-password-field.component.html
+++ b/src/app/signal-forms/components/fields/form-password-field/form-password-field.component.html
@@ -1,1 +1,14 @@
-<p>form-password-field works!</p>
+<div class="form-input-wrapper">
+  <input
+    type="password"
+    class="form-input"
+    [attr.name]="name()"
+    [placeholder]="config()?.placeholder"
+    [disabled]="disabled()"
+    [step]="config()?.precision ?? 1"
+    [(value)]="value"
+    (input)="handleInput($event)"
+    (change)="handleBlur()"
+    (blur)="handleBlur()"
+  />
+</div>

--- a/src/app/signal-forms/components/fields/form-password-field/form-password-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-password-field/form-password-field.component.ts
@@ -1,10 +1,10 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormFieldType } from '../../../enums/form-field-type.enum';
-import { AutocompleteFieldConfig } from '../../../models/signal-form.model';
+import { type PasswordFieldConfig } from '../../../models/signal-field-configs.model';
 import { BaseInputDirective } from '../../base/base-input/base-input.directive';
 
 @Component({
-  selector: 'app-form-password-field',
+  selector: 'signal-form-password-field',
   imports: [],
   templateUrl: './form-password-field.component.html',
   styleUrl: './form-password-field.component.scss',
@@ -13,5 +13,5 @@ import { BaseInputDirective } from '../../base/base-input/base-input.directive';
 export class FormPasswordFieldComponent extends BaseInputDirective<
   FormFieldType.PASSWORD,
   string,
-  AutocompleteFieldConfig
+  PasswordFieldConfig
 > {}

--- a/src/app/signal-forms/components/fields/form-radio-field/form-radio-field.component.html
+++ b/src/app/signal-forms/components/fields/form-radio-field/form-radio-field.component.html
@@ -1,1 +1,16 @@
-<p>form-radio-field works!</p>
+<div class="form-radio-group">
+  @for (option of options(); track option.value) {
+    <label class="form-radio-option">
+      <input
+        type="radio"
+        [attr.name]="'form-radio-' + name() + '-' + option.value"
+        [value]="option.value"
+        [checked]="value() === option.value"
+        [disabled]="disabled()"
+        (input)="handleInput($event)"
+        (blur)="handleBlur()"
+      />
+      {{ option.label }}
+    </label>
+  }
+</div>

--- a/src/app/signal-forms/components/fields/form-radio-field/form-radio-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-radio-field/form-radio-field.component.ts
@@ -1,12 +1,20 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { FormFieldType } from '../../../enums/form-field-type.enum';
+import { type RadioFieldConfig } from '../../../models/signal-field-configs.model';
+import { type FormOption } from '../../../models/signal-form.model';
+import { BaseInputDirective } from '../../base/base-input/base-input.directive';
 
 @Component({
-  selector: 'app-form-radio-field',
+  selector: 'signal-form-radio-field',
   imports: [],
   templateUrl: './form-radio-field.component.html',
   styleUrl: './form-radio-field.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FormRadioFieldComponent {
-
+export class FormRadioFieldComponent extends BaseInputDirective<
+  FormFieldType.RADIO,
+  FormOption,
+  RadioFieldConfig
+> {
+  public options = input.required<FormOption[]>();
 }

--- a/src/app/signal-forms/components/fields/form-rating-field/form-rating-field.component.html
+++ b/src/app/signal-forms/components/fields/form-rating-field/form-rating-field.component.html
@@ -1,0 +1,10 @@
+<div class="rating-stars" [attr.name]="name()">
+  @for (star of stars(); track $index) {
+    <span
+      class="star"
+      [class.filled]="value() >= star"
+      (click)="setRating(star)"
+      >★</span
+    >
+  }
+</div>

--- a/src/app/signal-forms/components/fields/form-rating-field/form-rating-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-rating-field/form-rating-field.component.scss
@@ -1,0 +1,14 @@
+.rating-stars {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+
+  .star {
+    color: #dcdcdc;
+
+    &.filled {
+      color: #00aeff;
+    }
+  }
+}

--- a/src/app/signal-forms/components/fields/form-rating-field/form-rating-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-rating-field/form-rating-field.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { BaseInputDirective } from '@base/base-input/base-input.directive';
+import { FormFieldType } from '@enums/form-field-type.enum';
+
+@Component({
+  selector: 'signal-form-rating-field',
+  imports: [],
+  templateUrl: './form-rating-field.component.html',
+  styleUrl: './form-rating-field.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormRatingFieldComponent extends BaseInputDirective<
+  FormFieldType.RATING,
+  number,
+  { max: number }
+> {
+  protected stars = computed(() =>
+    Array.from({ length: this.config()?.max ?? 5 }, (_, i) => i + 1),
+  );
+
+  public setRating(star: number): void {
+    this.setValue(star);
+    this.touched.set(true);
+  }
+}

--- a/src/app/signal-forms/components/fields/form-select-field/form-select-field.component.html
+++ b/src/app/signal-forms/components/fields/form-select-field/form-select-field.component.html
@@ -1,1 +1,12 @@
-<p>form-select-field works!</p>
+<div
+  class="form-select-wrapper"
+  tabindex="0"
+  [attr.name]="name()"
+  (click)="toggleDropdown()"
+  (keydown.enter)="toggleDropdown()"
+>
+  <div class="form-select-display">
+    {{ displayValue() || (config()?.placeholder ?? "Select an option") }}
+  </div>
+  <div class="form-select-arrow">▾</div>
+</div>

--- a/src/app/signal-forms/components/fields/form-select-field/form-select-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-select-field/form-select-field.component.scss
@@ -1,0 +1,23 @@
+.form-select-wrapper {
+  border: 1px solid #ccc;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 40px;
+
+  &:hover {
+    border-color: #999;
+  }
+}
+
+.form-select-display {
+  flex-grow: 1;
+}
+
+.form-select-arrow {
+  margin-left: 8px;
+  color: #666;
+}

--- a/src/app/signal-forms/components/fields/form-slider-field/form-slider-field.component.html
+++ b/src/app/signal-forms/components/fields/form-slider-field/form-slider-field.component.html
@@ -1,0 +1,12 @@
+<input
+  type="range"
+  class="form-slider"
+  [attr.name]="name()"
+  [min]="config()?.min"
+  [max]="config()?.max"
+  [step]="config()?.step ?? 1"
+  [value]="value()"
+  [disabled]="disabled()"
+  (input)="handleInput($event)"
+  (blur)="handleBlur()"
+/>

--- a/src/app/signal-forms/components/fields/form-slider-field/form-slider-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-slider-field/form-slider-field.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormFieldType } from '../../../enums/form-field-type.enum';
+import { type SliderFieldConfig } from '../../../models/signal-field-configs.model';
+import { BaseInputDirective } from '../../base/base-input/base-input.directive';
+
+@Component({
+  selector: 'signal-form-slider-field',
+  imports: [],
+  templateUrl: './form-slider-field.component.html',
+  styleUrl: './form-slider-field.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormSliderFieldComponent extends BaseInputDirective<
+  FormFieldType.SLIDER,
+  number,
+  SliderFieldConfig
+> {}

--- a/src/app/signal-forms/components/fields/form-switch-field/form-switch-field.component.html
+++ b/src/app/signal-forms/components/fields/form-switch-field/form-switch-field.component.html
@@ -1,0 +1,12 @@
+<label class="switch-wrapper">
+  <input
+    type="checkbox"
+    class="switch-input"
+    [attr.name]="name()"
+    [checked]="value()"
+    [disabled]="disabled()"
+    (input)="handleInput($event)"
+    (blur)="handleBlur()"
+  />
+  <span class="switch-slider"></span>
+</label>

--- a/src/app/signal-forms/components/fields/form-switch-field/form-switch-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-switch-field/form-switch-field.component.scss
@@ -1,0 +1,49 @@
+.switch-wrapper {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+
+  .switch-input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+
+  .switch-slider {
+    position: absolute;
+    cursor: pointer;
+    background-color: #ccc;
+    border-radius: 34px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    transition: 0.3s;
+
+    &:before {
+      position: absolute;
+      content: "";
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background-color: white;
+      border-radius: 50%;
+      transition: 0.3s;
+    }
+  }
+
+  .switch-input:checked + .switch-slider {
+    background-color: #4caf50;
+  }
+
+  .switch-input:checked + .switch-slider:before {
+    transform: translateX(20px);
+  }
+
+  .switch-input:disabled + .switch-slider {
+    background-color: #e0e0e0;
+    cursor: not-allowed;
+  }
+}

--- a/src/app/signal-forms/components/fields/form-switch-field/form-switch-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-switch-field/form-switch-field.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormFieldType } from '../../../enums/form-field-type.enum';
+import { type SwitchFieldConfig } from '../../../models/signal-field-configs.model';
+import { BaseInputDirective } from '../../base/base-input/base-input.directive';
+
+@Component({
+  selector: 'signal-form-switch-field',
+  imports: [],
+  templateUrl: './form-switch-field.component.html',
+  styleUrl: './form-switch-field.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormSwitchFieldComponent extends BaseInputDirective<
+  FormFieldType.SWITCH,
+  boolean,
+  SwitchFieldConfig
+> {}

--- a/src/app/signal-forms/components/fields/form-text-field/form-text-field.component.html
+++ b/src/app/signal-forms/components/fields/form-text-field/form-text-field.component.html
@@ -3,6 +3,7 @@
     type="text"
     class="form-input"
     [placeholder]="config()?.placeholder"
+    [attr.name]="name()"
     [disabled]="disabled()"
     [(value)]="value"
     (input)="handleInput($event)"

--- a/src/app/signal-forms/components/fields/form-text-field/form-text-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-text-field/form-text-field.component.ts
@@ -10,7 +10,7 @@ export interface TextFieldConfig {
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
-  selector: 'app-form-text-field',
+  selector: 'signal-form-text-field',
   standalone: true,
   templateUrl: 'form-text-field.component.html',
 })

--- a/src/app/signal-forms/components/fields/form-textarea-field/form-textarea-field.component.html
+++ b/src/app/signal-forms/components/fields/form-textarea-field/form-textarea-field.component.html
@@ -1,1 +1,12 @@
-<p>form-textarea-field works!</p>
+<div class="form-input-wrapper">
+  <textarea
+    class="form-input"
+    [attr.name]="name()"
+    [placeholder]="config()?.placeholder"
+    [disabled]="disabled()"
+    [(value)]="value"
+    (input)="handleInput($event)"
+    (change)="handleBlur()"
+    (blur)="handleBlur()"
+  ></textarea>
+</div>

--- a/src/app/signal-forms/components/fields/form-textarea-field/form-textarea-field.component.scss
+++ b/src/app/signal-forms/components/fields/form-textarea-field/form-textarea-field.component.scss
@@ -1,0 +1,4 @@
+textarea.form-input {
+  min-height: 80px;
+  resize: vertical;
+}

--- a/src/app/signal-forms/components/fields/form-textarea-field/form-textarea-field.component.ts
+++ b/src/app/signal-forms/components/fields/form-textarea-field/form-textarea-field.component.ts
@@ -1,12 +1,17 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormFieldType } from '../../../enums/form-field-type.enum';
+import { BaseInputDirective } from '../../base/base-input/base-input.directive';
+import { TextFieldConfig } from '../form-text-field/form-text-field.component';
 
 @Component({
-  selector: 'app-form-textarea-field',
+  selector: 'signal-form-textarea-field',
   imports: [],
   templateUrl: './form-textarea-field.component.html',
   styleUrl: './form-textarea-field.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FormTextareaFieldComponent {
-
-}
+export class FormTextareaFieldComponent extends BaseInputDirective<
+  FormFieldType.TEXTAREA,
+  string,
+  TextFieldConfig
+> {}

--- a/src/app/signal-forms/components/renderers/form-field-error-summary/signal-form-error-summary.component.ts
+++ b/src/app/signal-forms/components/renderers/form-field-error-summary/signal-form-error-summary.component.ts
@@ -5,7 +5,7 @@ import {
   input,
   signal,
 } from '@angular/core';
-import { SignalFormContainer } from '../../../models/signal-form.model';
+import { type SignalFormContainer } from '../../../models/signal-form.model';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/signal-forms/components/renderers/signal-form-fields/signal-form-fields.component.html
+++ b/src/app/signal-forms/components/renderers/signal-form-fields/signal-form-fields.component.html
@@ -3,6 +3,7 @@
     <section
       class="nested-form-section"
       [class]="'form-group-' + (field.config?.view ?? 'stacked')"
+      [style.gridArea]="field.name"
     >
       @if (field.config?.view === "collapsable") {
         <collapsible-section

--- a/src/app/signal-forms/components/renderers/signal-form-fields/signal-form-fields.component.scss
+++ b/src/app/signal-forms/components/renderers/signal-form-fields/signal-form-fields.component.scss
@@ -6,6 +6,12 @@
       flex: 1 1;
     }
   }
+
+  &.grid {
+    display: grid;
+    width: 100%;
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .nested-form {

--- a/src/app/signal-forms/components/renderers/signal-form-input-item/signal-form-input-item.component.html
+++ b/src/app/signal-forms/components/renderers/signal-form-input-item/signal-form-input-item.component.html
@@ -5,44 +5,196 @@
     [class.is-success]="!field().error() && field().value()"
     [attr.data-form-field]="field().name"
   >
-    <label class="form-label">{{ field().label }}</label>
+    @if (field().type !== FormFieldType.CHECKBOX) {
+      <label class="form-label">{{ field().label }}</label>
+    }
     @switch (field().type) {
       @case (FormFieldType.TEXT) {
-        <app-form-text-field
+        <signal-form-text-field
           [(touched)]="field().touched"
           [(dirty)]="field().dirty"
           [(value)]="field().value"
+          [(error)]="field().error"
+          [name]="field().name"
+          [config]="field().config"
+          [disabled]="isDisabled()"
+        />
+      }
+      @case (FormFieldType.PASSWORD) {
+        <signal-form-password-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [name]="field().name"
           [config]="field().config"
           [disabled]="isDisabled()"
         />
       }
       @case (FormFieldType.CHECKBOX) {
-        <app-form-checkbox-field
+        <signal-form-checkbox-field
           [(touched)]="field().touched"
           [(dirty)]="field().dirty"
           [(value)]="field().value"
+          [(error)]="field().error"
+          [label]="field().label"
+          [name]="field().name"
           [config]="field().config"
           [disabled]="isDisabled()"
         />
       }
 
       @case (FormFieldType.NUMBER) {
-        <app-form-number-field
+        <signal-form-number-field
           [(touched)]="field().touched"
           [(dirty)]="field().dirty"
           [(value)]="field().value"
+          [(error)]="field().error"
           [config]="field().config"
+          [name]="field().name"
           [disabled]="isDisabled()"
         />
       }
 
       @case (FormFieldType.AUTOCOMPLETE) {
-        <app-form-autocomplete-field
+        <signal-form-autocomplete-field
           [(touched)]="field().touched"
           [(dirty)]="field().dirty"
           [(value)]="field().value"
+          [(error)]="field().error"
           [config]="field().config"
+          [name]="field().name"
           [loadOptions]="field().loadOptions"
+          [disabled]="isDisabled()"
+        />
+      }
+
+      @case (FormFieldType.TEXTAREA) {
+        <signal-form-textarea-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
+          [disabled]="isDisabled()"
+        />
+      }
+
+      @case (FormFieldType.SELECT) {
+        <signal-form-select-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [disabled]="isDisabled()"
+          [name]="field().name"
+          [options]="field().options"
+        />
+      }
+
+      @case (FormFieldType.RADIO) {
+        <signal-form-radio-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
+          [disabled]="isDisabled()"
+          [options]="field().options"
+        />
+      }
+
+      @case (FormFieldType.DATETIME) {
+        <signal-form-datetime-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
+          [disabled]="isDisabled()"
+        />
+      }
+
+      @case (FormFieldType.MULTISELECT) {
+        <signal-form-multiselect-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [disabled]="isDisabled()"
+          [name]="field().name"
+          [options]="field().options"
+        />
+      }
+
+      @case (FormFieldType.FILE) {
+        <signal-form-file-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
+          [disabled]="isDisabled()"
+        />
+      }
+      @case (FormFieldType.COLOR) {
+        <signal-form-color-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
+          [disabled]="isDisabled()"
+        />
+      }
+      @case (FormFieldType.MASKED) {
+        <signal-form-masked-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
+          [disabled]="isDisabled()"
+        />
+      }
+      @case (FormFieldType.RATING) {
+        <signal-form-rating-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
+          [disabled]="isDisabled()"
+        />
+      }
+      @case (FormFieldType.SLIDER) {
+        <signal-form-slider-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
+          [disabled]="isDisabled()"
+        />
+      }
+      @case (FormFieldType.SWITCH) {
+        <signal-form-switch-field
+          [(touched)]="field().touched"
+          [(dirty)]="field().dirty"
+          [(value)]="field().value"
+          [(error)]="field().error"
+          [config]="field().config"
+          [name]="field().name"
           [disabled]="isDisabled()"
         />
       }

--- a/src/app/signal-forms/components/renderers/signal-form-input-item/signal-form-input-item.component.scss
+++ b/src/app/signal-forms/components/renderers/signal-form-input-item/signal-form-input-item.component.scss
@@ -1,5 +1,1 @@
-::host {
-  .form-error-highlight {
-    border: 1px solid red;
-  }
-}
+

--- a/src/app/signal-forms/components/renderers/signal-form-input-item/signal-form-input-item.component.ts
+++ b/src/app/signal-forms/components/renderers/signal-form-input-item/signal-form-input-item.component.ts
@@ -4,32 +4,60 @@ import {
   computed,
   effect,
   ElementRef,
+  HostBinding,
   Injector,
   input,
+  Optional,
   Renderer2,
   signal,
   WritableSignal,
 } from '@angular/core';
+import { FormColorFieldComponent } from '@fields/form-color-field/form-color-field.component';
+import { FormFileFieldComponent } from '@fields/form-file-field/form-file-field.component';
+import { FormMaskedFieldComponent } from '@fields/form-masked-field/form-masked-field.component';
+import { FormRatingFieldComponent } from '@fields/form-rating-field/form-rating-field.component';
+import { FormSliderFieldComponent } from '@fields/form-slider-field/form-slider-field.component';
+import { FormSwitchFieldComponent } from '@fields/form-switch-field/form-switch-field.component';
 import { FormFieldType } from '../../../enums/form-field-type.enum';
 import {
-  SignalFormContainer,
-  SignalFormField,
+  type SignalFormContainer,
+  type SignalFormField,
 } from '../../../models/signal-form.model';
+import { SignalFormHostDirective } from '../../base/host-directive/signal-form-host.directive';
 import { FormAutocompleteFieldComponent } from '../../fields/form-autocomplete-field/form-autocomplete-field.component';
 import { FormCheckboxFieldComponent } from '../../fields/form-checkbox-field/form-checkbox-field.component';
+import { FormDatetimeFieldComponent } from '../../fields/form-datetime-field/form-datetime-field.component';
+import { FormMultiselectFieldComponent } from '../../fields/form-multiselect-field/form-multiselect-field.component';
 import { FormNumberFieldComponent } from '../../fields/form-number-field/form-number-field.component';
+import { FormPasswordFieldComponent } from '../../fields/form-password-field/form-password-field.component';
+import { FormRadioFieldComponent } from '../../fields/form-radio-field/form-radio-field.component';
+import { FormSelectFieldComponent } from '../../fields/form-select-field/form-select-field.component';
 import { FormTextFieldComponent } from '../../fields/form-text-field/form-text-field.component';
+import { FormTextareaFieldComponent } from '../../fields/form-textarea-field/form-textarea-field.component';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   selector: 'signal-form-input-item',
   imports: [
-    FormNumberFieldComponent,
-    FormCheckboxFieldComponent,
-    FormTextFieldComponent,
     FormAutocompleteFieldComponent,
+    FormCheckboxFieldComponent,
+    FormDatetimeFieldComponent,
+    FormFileFieldComponent,
+    FormMultiselectFieldComponent,
+    FormNumberFieldComponent,
+    FormPasswordFieldComponent,
+    FormRadioFieldComponent,
+    FormSelectFieldComponent,
+    FormTextFieldComponent,
+    FormTextareaFieldComponent,
+    FormColorFieldComponent,
+    FormMaskedFieldComponent,
+    FormRatingFieldComponent,
+    FormSliderFieldComponent,
+    FormSwitchFieldComponent,
   ],
+  hostDirectives: [SignalFormHostDirective],
   templateUrl: './signal-form-input-item.component.html',
   styleUrl: './signal-form-input-item.component.scss',
 })
@@ -41,10 +69,17 @@ export class SignalFormInputItemComponent<TModel> {
 
   private initialized = signal(false);
 
+  @HostBinding('style.gridArea')
+  get gridArea(): string | null {
+    return this.field()?.name?.toString() ?? null;
+  }
+
   constructor(
-    private renderer: Renderer2,
-    private host: ElementRef,
-    private injector: Injector,
+    private readonly renderer: Renderer2,
+    private readonly host: ElementRef,
+    private readonly injector: Injector,
+    @Optional()
+    private readonly signalFormHostDirective: SignalFormHostDirective,
   ) {
     this.initializeComputedValueEffect();
     this.watchComputedValueEffect();
@@ -115,7 +150,6 @@ export class SignalFormInputItemComponent<TModel> {
         input.focus?.();
 
         this.renderer.addClass(el, 'form-error-highlight');
-        console.log(el);
 
         setTimeout(() => {
           this.renderer.removeClass(el, 'form-error-highlight');

--- a/src/app/signal-forms/components/renderers/signal-form-save-button/signal-form-save-button.component.ts
+++ b/src/app/signal-forms/components/renderers/signal-form-save-button/signal-form-save-button.component.ts
@@ -4,7 +4,7 @@ import {
   input,
   output,
 } from '@angular/core';
-import { SignalFormContainer } from '../../../models/signal-form.model';
+import { type SignalFormContainer } from '../../../models/signal-form.model';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/signal-forms/components/renderers/signal-form/signal-form.component.ts
+++ b/src/app/signal-forms/components/renderers/signal-form/signal-form.component.ts
@@ -5,7 +5,8 @@ import {
   input,
   output,
 } from '@angular/core';
-import { SignalFormContainer } from '../../../models/signal-form.model';
+import { type SignalFormContainer } from '../../../models/signal-form.model';
+import { SignalFormHostDirective } from '../../base/host-directive/signal-form-host.directive';
 import { SignalFormErrorSummaryComponent } from '../form-field-error-summary/signal-form-error-summary.component';
 import { SignalFormFieldsComponent } from '../signal-form-fields/signal-form-fields.component';
 
@@ -16,6 +17,7 @@ import { SignalFormFieldsComponent } from '../signal-form-fields/signal-form-fie
   standalone: true,
   styleUrl: './signal-form.component.scss',
   templateUrl: './signal-form.component.html',
+  hostDirectives: [SignalFormHostDirective],
 })
 export class SignalFormComponent<TModel> {
   public form = input.required<SignalFormContainer<TModel>>();

--- a/src/app/signal-forms/components/ui/collapsible-section/collapsible-section.component.ts
+++ b/src/app/signal-forms/components/ui/collapsible-section/collapsible-section.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -17,7 +17,7 @@ import { expandCollapse, growFadeIn } from '../../../animations/animations';
 @Component({
   selector: 'collapsible-section',
   standalone: true,
-  imports: [CommonModule, LucideAngularModule],
+  imports: [NgTemplateOutlet, LucideAngularModule],
   animations: [expandCollapse, growFadeIn],
   templateUrl: './collapsible-section.component.html',
   styleUrls: ['./collapsible-section.component.scss'],
@@ -51,7 +51,6 @@ export class CollapsibleSectionComponent {
   protected shouldShow = computed(() => !this.collapsed() || this.collapsing());
 
   protected onDone(event: ExpandedAnimationEvent): void {
-    console.log(event);
     if (event.toState === 'closed') {
       this.collapsed.set(true);
       this.collapsing.set(false);

--- a/src/app/signal-forms/components/ui/form-dropdown-overlay/form-dropdown-overlay.component.html
+++ b/src/app/signal-forms/components/ui/form-dropdown-overlay/form-dropdown-overlay.component.html
@@ -1,0 +1,17 @@
+<ul class="dropdown-options">
+  @for (option of options(); track option.value) {
+    <li
+      class="dropdown-option"
+      [attr.data-index]="$index"
+      [class.selected]="isSelected(option)"
+      [class.focused]="focusedIndex() === $index"
+      (click)="selectOption(option)"
+      #optionElement
+    >
+      {{ option.label }}
+      @if (isSelected(option) && multiselect()) {
+        <lucide-icon class="selected-icon" [img]="checkIcon" />
+      }
+    </li>
+  }
+</ul>

--- a/src/app/signal-forms/components/ui/form-dropdown-overlay/form-dropdown-overlay.component.scss
+++ b/src/app/signal-forms/components/ui/form-dropdown-overlay/form-dropdown-overlay.component.scss
@@ -1,0 +1,24 @@
+.dropdown-options {
+  background: white;
+  border: 1px solid #ccc;
+  max-height: 200px;
+  overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    padding: 8px 12px;
+    cursor: pointer;
+
+    &.focused {
+      background-color: #e0f0ff;
+    }
+
+    &:hover {
+      background: #f2f2f2;
+    }
+  }
+}

--- a/src/app/signal-forms/components/ui/form-dropdown-overlay/form-dropdown-overlay.component.spec.ts
+++ b/src/app/signal-forms/components/ui/form-dropdown-overlay/form-dropdown-overlay.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormDropdownOverlayComponent } from './form-dropdown-overlay.component';
+
+describe('FormDropdownOverlayComponent', () => {
+  let component: FormDropdownOverlayComponent;
+  let fixture: ComponentFixture<FormDropdownOverlayComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FormDropdownOverlayComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FormDropdownOverlayComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/signal-forms/components/ui/form-dropdown-overlay/form-dropdown-overlay.component.ts
+++ b/src/app/signal-forms/components/ui/form-dropdown-overlay/form-dropdown-overlay.component.ts
@@ -1,0 +1,219 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  effect,
+  ElementRef,
+  Injector,
+  input,
+  OnInit,
+  output,
+  Renderer2,
+  signal,
+  viewChildren,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { type FormOption } from '@models/signal-form.model';
+import { CheckIcon, LucideAngularModule } from 'lucide-angular';
+import { fromEvent, tap } from 'rxjs';
+
+@Component({
+  selector: 'form-dropdown-overlay',
+  standalone: true,
+  imports: [LucideAngularModule],
+  templateUrl: './form-dropdown-overlay.component.html',
+  styleUrl: './form-dropdown-overlay.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormDropdownOverlayComponent implements OnInit {
+  public options = input.required<FormOption[]>();
+  public multiselect = input<boolean>(false);
+  public triggerElement = input<HTMLElement>();
+  public initialSelection = input<FormOption[] | FormOption>();
+
+  public select = output<FormOption | FormOption[] | null>();
+  public close = output<void>();
+
+  public optionElements = viewChildren('optionElement', { read: ElementRef });
+
+  protected focusedIndex = signal<number>(-1);
+  protected selectedOptions = signal<FormOption[]>([]);
+
+  protected readonly checkIcon = CheckIcon;
+
+  constructor(
+    private readonly renderer: Renderer2,
+    private readonly elementRef: ElementRef,
+    private readonly destroyRef: DestroyRef,
+    private readonly injector: Injector,
+  ) {}
+
+  public ngOnInit(): void {
+    this.handleSingleOrMultiSelect();
+    this.listenToDocumentMouseClicks();
+    this.listenToTriggerElementKeyDown();
+    this.listenToOptionElementForView();
+  }
+
+  private handleSingleOrMultiSelect(): void {
+    const selection = this.initialSelection();
+
+    if (!selection) {
+      return;
+    }
+
+    if (this.multiselect() && Array.isArray(selection)) {
+      this.selectedOptions.set(selection);
+      return;
+    }
+
+    this.selectedOptions.set([selection as FormOption]);
+  }
+
+  public selectOption(option: FormOption): void {
+    if (this.multiselect()) {
+      const current = (this.selectedOptions() as FormOption[]) ?? [];
+      const exists = current.some((o) => o.value === option.value);
+      const updated = exists
+        ? current.filter((o) => o.value !== option.value)
+        : [...current, option];
+
+      this.selectedOptions.set(updated);
+      this.select.emit(updated);
+    } else {
+      this.selectedOptions.set([option]);
+      this.emitSelection();
+    }
+  }
+
+  private emitSelection(): void {
+    const result = this.multiselect()
+      ? this.selectedOptions()
+      : (this.selectedOptions()[0] ?? null);
+
+    this.select.emit(result);
+  }
+
+  public toggleOption(option: FormOption): void {
+    if (this.multiselect()) {
+      this.selectedOptions.update((current) => {
+        const exists = current.some((o) => o.value === option.value);
+        return exists
+          ? current.filter((o) => o.value !== option.value)
+          : [...current, option];
+      });
+    } else {
+      this.selectedOptions.set([option]);
+      this.emitSelection();
+    }
+  }
+
+  public setPosition({
+    top,
+    left,
+    width,
+  }: {
+    top: number;
+    left: number;
+    width: number;
+  }): void {
+    const el = this.elementRef.nativeElement;
+
+    Object.entries({
+      position: 'absolute',
+      top: `${top}px`,
+      left: `${left}px`,
+      width: `${width}px`,
+      zIndex: 1000,
+    }).forEach(([key, val]) => this.renderer.setStyle(el, key, val));
+  }
+
+  protected isSelected(formOption: FormOption): boolean {
+    const selectedOptions = this.selectedOptions();
+
+    if (!this.selectedOptions()) {
+      return false;
+    }
+    return selectedOptions.some((option) => option.value === formOption.value);
+  }
+
+  private listenToDocumentMouseClicks(): void {
+    fromEvent<MouseEvent>(document, 'click')
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((event) => {
+        const target = event.target as Node;
+
+        const clickedInsideOverlay =
+          this.elementRef.nativeElement.contains(target);
+        const clickedOnTrigger = this.triggerElement()?.contains(target);
+
+        if (!clickedInsideOverlay && !clickedOnTrigger) {
+          this.close.emit();
+        }
+      });
+  }
+
+  private listenToTriggerElementKeyDown(): void {
+    if (!this.triggerElement()) {
+      return;
+    }
+
+    fromEvent<KeyboardEvent>(this.triggerElement()!, 'keydown')
+      .pipe(
+        tap((event) => this.handleKeydown(event)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private handleKeydown(event: KeyboardEvent): void {
+    const options = this.options();
+    const max = options.length - 1;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.focusedIndex.update((i) => (i + 1 > max ? 0 : i + 1));
+        break;
+
+      case 'ArrowUp':
+        event.preventDefault();
+        this.focusedIndex.update((i) => (i - 1 < 0 ? max : i - 1));
+        break;
+
+      case 'Enter':
+        event.preventDefault();
+        const selected = options[this.focusedIndex()];
+        if (selected) this.selectOption(selected);
+        break;
+
+      case 'Escape':
+        this.close.emit();
+        break;
+    }
+  }
+
+  private listenToOptionElementForView(): void {
+    effect(
+      () => {
+        const index = this.focusedIndex();
+
+        if (index === -1) {
+          return;
+        }
+
+        const el = this.optionElements().at(index)?.nativeElement;
+
+        if (el) {
+          el.scrollIntoView({
+            behavior: 'smooth',
+            block: 'nearest',
+          });
+        }
+      },
+      {
+        injector: this.injector,
+      },
+    );
+  }
+}

--- a/src/app/signal-forms/enums/currency-type.enum.ts
+++ b/src/app/signal-forms/enums/currency-type.enum.ts
@@ -1,0 +1,4 @@
+export enum CurrencyType {
+  Cad = 'CAD',
+  Usd = 'USD',
+}

--- a/src/app/signal-forms/enums/form-field-type.enum.ts
+++ b/src/app/signal-forms/enums/form-field-type.enum.ts
@@ -8,4 +8,12 @@ export enum FormFieldType {
   NUMBER = 'number',
   CHECKBOX = 'checkbox',
   DATETIME = 'datetime',
+  COLOR = 'color',
+  SWITCH = 'switch',
+  SLIDER = 'slider',
+  FILE = 'file',
+  RATING = 'rating',
+  MASKED = 'masked',
+  MULTISELECT = 'multiselect',
+  CHIPLIST = 'chiplist',
 }

--- a/src/app/signal-forms/helpers/mask-parser.ts
+++ b/src/app/signal-forms/helpers/mask-parser.ts
@@ -1,0 +1,93 @@
+export type MaskToken = '9' | 'A' | '*';
+export type MaskDefinition = Record<MaskToken, RegExp>;
+
+export class MaskParser {
+  static readonly DEFAULT_MASK_DEFINITION: MaskDefinition = {
+    '9': /\d/,
+    A: /[a-zA-Z]/,
+    '*': /[a-zA-Z0-9]/,
+  };
+
+  public static format(
+    value: string,
+    mask: string,
+    defs = this.DEFAULT_MASK_DEFINITION,
+  ): string {
+    let result = '';
+    let rawIndex = 0;
+
+    for (let i = 0; i < mask.length; i++) {
+      const maskChar = mask[i];
+      const def = defs[maskChar as MaskToken];
+
+      if (def) {
+        while (rawIndex < value.length) {
+          const rawChar = value[rawIndex++];
+          if (def.test(rawChar)) {
+            result += rawChar;
+            break;
+          }
+        }
+      } else {
+        result += maskChar;
+      }
+    }
+
+    return result;
+  }
+
+  public static unmask(
+    formatted: string,
+    mask: string,
+    defs = this.DEFAULT_MASK_DEFINITION,
+  ): string {
+    let raw = '';
+    for (let i = 0; i < mask.length && i < formatted.length; i++) {
+      const def = defs[mask[i] as MaskToken];
+      if (def && def.test(formatted[i])) {
+        raw += formatted[i];
+      }
+    }
+    return raw;
+  }
+
+  public static getEditableLength(
+    mask: string,
+    defs = this.DEFAULT_MASK_DEFINITION,
+  ): number {
+    return [...mask].filter((c) => defs[c as MaskToken]).length;
+  }
+
+  public static getMaxLength(mask: string): number {
+    return mask.length;
+  }
+
+  public static getNextEditableIndex(
+    mask: string,
+    pos: number,
+    defs = this.DEFAULT_MASK_DEFINITION,
+  ): number {
+    for (let i = pos; i < mask.length; i++) {
+      if (defs[mask[i] as MaskToken]) return i;
+    }
+    return mask.length;
+  }
+
+  public static getPreviousEditableIndex(
+    mask: string,
+    pos: number,
+    defs = this.DEFAULT_MASK_DEFINITION,
+  ): number {
+    for (let i = pos - 1; i >= 0; i--) {
+      if (defs[mask[i] as MaskToken]) return i;
+    }
+    return 0;
+  }
+
+  public static getEditableIndices(mask: string): number[] {
+    const defs = this.DEFAULT_MASK_DEFINITION;
+    return [...mask]
+      .map((char, i) => (defs[char as keyof typeof defs] ? i : -1))
+      .filter((i) => i !== -1);
+  }
+}

--- a/src/app/signal-forms/models/signal-field-configs.model.ts
+++ b/src/app/signal-forms/models/signal-field-configs.model.ts
@@ -1,0 +1,102 @@
+import { CurrencyType } from '../enums/currency-type.enum';
+import { FormFieldType } from '../enums/form-field-type.enum';
+
+/**
+ * this config is extended on every other config type
+ */
+export interface BaseFieldConfig {
+  placeholder?: string;
+  hint?: string;
+}
+
+export interface TextFieldConfig extends BaseFieldConfig {
+  prefix?: string;
+  suffix?: string;
+}
+export interface NumberFieldConfig extends BaseFieldConfig {
+  currency?: CurrencyType;
+  prefix?: string;
+  suffix?: string;
+  precision?: number;
+}
+export interface CheckboxFieldConfig extends BaseFieldConfig {
+  layout?: 'inline' | 'stacked';
+}
+export interface DateTimeFieldConfig extends BaseFieldConfig {
+  format?: string;
+}
+export interface AutocompleteFieldConfig extends BaseFieldConfig {
+  debounceMs?: number;
+  minChars?: number;
+}
+export interface SelectFieldConfig extends BaseFieldConfig {
+  multiselect?: boolean;
+}
+export interface SliderFieldConfig extends BaseFieldConfig {
+  min?: number;
+  max?: number;
+  step?: number;
+}
+export interface FileFieldConfig extends BaseFieldConfig {
+  accept?: string;
+  maxSizeMb?: number;
+  multiple?: boolean;
+}
+export interface RatingFieldConfig extends BaseFieldConfig {
+  max?: number;
+  allowHalf?: boolean;
+}
+export interface MaskedFieldConfig extends BaseFieldConfig {
+  mask: string; // e.g., "(999) 999-9999"
+  placeholderChar?: string; // e.g, "_"
+}
+
+export interface TextAreaFieldConfig extends BaseFieldConfig {}
+export interface PasswordFieldConfig extends BaseFieldConfig {}
+export interface RadioFieldConfig extends BaseFieldConfig {}
+export interface MultiSelectFieldConfig extends BaseFieldConfig {}
+export interface ColorFieldConfig extends BaseFieldConfig {
+  view: 'swatch' | 'pickerWithInput';
+}
+export interface SwitchFieldConfig extends BaseFieldConfig {}
+export interface ChipListFieldConfig extends BaseFieldConfig {}
+
+//
+// ========== Config Type Mapping ==========
+//
+export type ConfigTypeForField<T extends FormFieldType> =
+  T extends FormFieldType.TEXT
+    ? TextFieldConfig
+    : T extends FormFieldType.PASSWORD
+      ? PasswordFieldConfig
+      : T extends FormFieldType.TEXTAREA
+        ? TextAreaFieldConfig
+        : T extends FormFieldType.SELECT
+          ? SelectFieldConfig
+          : T extends FormFieldType.RADIO
+            ? RadioFieldConfig
+            : T extends FormFieldType.AUTOCOMPLETE
+              ? AutocompleteFieldConfig
+              : T extends FormFieldType.NUMBER
+                ? NumberFieldConfig
+                : T extends FormFieldType.CHECKBOX
+                  ? CheckboxFieldConfig
+                  : T extends FormFieldType.DATETIME
+                    ? DateTimeFieldConfig
+                    : T extends FormFieldType.COLOR
+                      ? ColorFieldConfig
+                      : T extends FormFieldType.SWITCH
+                        ? SwitchFieldConfig
+                        : T extends FormFieldType.SLIDER
+                          ? SliderFieldConfig
+                          : T extends FormFieldType.FILE
+                            ? FileFieldConfig
+                            : T extends FormFieldType.RATING
+                              ? RatingFieldConfig
+                              : T extends FormFieldType.MASKED
+                                ? MaskedFieldConfig
+                                : T extends FormFieldType.MULTISELECT
+                                  ? MultiSelectFieldConfig
+                                  : T extends FormFieldType.CHIPLIST
+                                    ? ChipListFieldConfig
+                                    : never;

--- a/src/app/signal-forms/services/form-dropdown.service.ts
+++ b/src/app/signal-forms/services/form-dropdown.service.ts
@@ -1,0 +1,73 @@
+import {
+  ApplicationRef,
+  ComponentRef,
+  Injectable,
+  Injector,
+  ViewContainerRef,
+} from '@angular/core';
+import { FormDropdownOverlayComponent } from '../components/ui/form-dropdown-overlay/form-dropdown-overlay.component';
+import { type FormOption } from '../models/signal-form.model';
+
+@Injectable({ providedIn: 'root' })
+export class FormDropdownService {
+  private dropdownRef?: ComponentRef<FormDropdownOverlayComponent>;
+
+  constructor(
+    private readonly appRef: ApplicationRef,
+    private readonly injector: Injector,
+  ) {}
+
+  public openDropdown<TVal>(config: {
+    options: FormOption[];
+    reference: HTMLElement;
+    viewContainerRef: ViewContainerRef;
+    onSelect: (option: TVal) => void;
+    onClose?: () => void;
+    initialSelection?: TVal | null;
+    multiselect: boolean;
+  }): void {
+    this.destroyDropdown();
+
+    this.dropdownRef = config.viewContainerRef.createComponent(
+      FormDropdownOverlayComponent,
+      {
+        environmentInjector: this.appRef.injector,
+        injector: this.injector,
+      },
+    );
+
+    const instance = this.dropdownRef.instance;
+
+    this.dropdownRef.setInput('options', config.options);
+    this.dropdownRef.setInput('triggerElement', config.reference);
+    this.dropdownRef.setInput('multiselect', config.multiselect);
+    this.dropdownRef.setInput('initialSelection', config.initialSelection);
+
+    instance.select.subscribe((option) => {
+      config.onSelect(option as TVal);
+
+      if (!config.multiselect) {
+        this.destroyDropdown();
+      }
+    });
+
+    instance.close.subscribe(() => {
+      config.onClose?.();
+      this.destroyDropdown();
+    });
+
+    requestAnimationFrame(() => {
+      const rect = config.reference.getBoundingClientRect();
+      instance.setPosition({
+        top: rect.bottom + window.scrollY,
+        left: rect.left + window.scrollX,
+        width: rect.width,
+      });
+    });
+  }
+
+  public destroyDropdown(): void {
+    this.dropdownRef?.destroy();
+    this.dropdownRef = undefined;
+  }
+}

--- a/src/app/signal-forms/services/test-http.service.ts
+++ b/src/app/signal-forms/services/test-http.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Country } from '../../app.component';
+
+@Injectable({ providedIn: 'root' })
+export class TestApiService {
+  constructor(private httpClient: HttpClient) {}
+
+  public getCountry(search: string): Observable<Country[]> {
+    return this.httpClient.get<Country[]>(
+      `https://restcountries.com/v3.1/name/${search}`,
+    );
+  }
+
+  public getPokemon(search: string): Observable<unknown[]> {
+    return this.httpClient.get<unknown[]>(
+      `https://pokeapi.co/api/v2/pokemon/${search}`,
+    );
+  }
+}

--- a/src/app/signal-forms/validators/signal-validators.ts
+++ b/src/app/signal-forms/validators/signal-validators.ts
@@ -1,6 +1,6 @@
 import {
-  SignalFormContainer,
-  SignalValidatorFn,
+  type SignalFormContainer,
+  type SignalValidatorFn,
 } from '../models/signal-form.model';
 
 export class SignalValidators {

--- a/src/styles/forms.scss
+++ b/src/styles/forms.scss
@@ -3,14 +3,12 @@
   flex-direction: column;
   gap: 4px;
 
-  &.has-error .form-input-wrapper {
-    border: 1px solid #f44336;
-    background-color: #fff6f6;
-  }
+  &.has-error .form-input {
+    border-color: #f44336;
 
-  &.is-success .form-input-wrapper {
-    border: 1px solid #00c292;
-    background-color: #f6fff9;
+    &:focus {
+      outline-color: #f44336;
+    }
   }
 }
 
@@ -23,20 +21,7 @@
 
 .form-input-wrapper {
   position: relative;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  padding: 6px 12px;
   display: flex;
-  align-items: center;
-  background-color: #fff;
-  transition:
-    border-color 0.2s,
-    box-shadow 0.2s;
-
-  &:focus-within {
-    border-color: #3f51b5;
-    box-shadow: 0 0 0 1px #3f51b5;
-  }
 
   & > * {
     flex: 1 0 100%;
@@ -45,12 +30,24 @@
 }
 
 .form-input {
-  border: none;
-  outline: none;
-  flex: 1;
-  font-size: 15px;
-  background: transparent;
-  padding: 4px 0;
+  font-size: 1rem;
+  width: 100%;
+  color: #334155;
+  padding-block: 0.5rem;
+  padding-inline: 0.75rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  box-shadow:
+    0 0 #0000,
+    0 0 #0000,
+    0 1px 2px 0 rgba(18, 18, 23, 0.05);
+  transition:
+    background 0.2s,
+    color 0.2s,
+    border-color 0.2s,
+    outline-color 0.2s,
+    box-shadow 0.2s;
+  appearance: none;
 
   &.filled {
     font-weight: 500;
@@ -154,4 +151,15 @@ signal-form-fields {
 .form-button:disabled {
   background-color: #b3cdfa;
   cursor: not-allowed;
+}
+
+.form-error-highlight {
+  & .form-input {
+    border-width: 2px;
+    animation: shake 0.3s ease-in-out;
+
+    &:focus {
+      border-width: 3px;
+    }
+  }
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -16,12 +16,6 @@ body {
   font-family: "Roboto", sans-serif;
 }
 
-.form-error-highlight {
-  outline: 2px solid #f44336;
-  box-shadow: 0 0 4px 2px #ff7a71;
-  animation: shake 0.3s ease-in-out;
-}
-
 @keyframes shake {
   0% {
     transform: translateX(0);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,18 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022"
+    "module": "ES2022",
+    "baseUrl": "./src",
+    "paths": {
+      "@models/*": ["app/signal-forms/models/*"],
+      "@services/*": ["app/signal-forms/services/*"],
+      "@validators/*": ["app/signal-forms/validators/*"],
+      "@enums/*": ["app/signal-forms/enums/*"],
+      "@renderers/*": ["app/signal-forms/components/renderers/*"],
+      "@fields/*": ["app/signal-forms/components/fields/*"],
+      "@base/*": ["app/signal-forms/components/base/*"],
+      "@ui/*": ["app/signal-forms/components/ui/*"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
adds a LOT more form fields ( all primary versions ) and adds the ability to have: 

```ts
config: {
layout: 'grid-area',
gridArea: [
// acts like grid-template-area but with nested arrays, and infers based on the keyof TModel + `.`
]
}
```

to apply custom layouts for sections