### PR TITLE
features(form-builder): create patch and set form methods

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,6 @@
 <router-outlet />
 
 @if (!!form) {
+  <button type="button" (click)="updateForm()">update the form</button>
   <app-signal-form [form]="form" (onSave)="save($event)" />
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1417,6 +1417,7 @@ export class AppComponent implements OnInit {
           name: 'brightness',
           label: 'Brightness',
           type: FormFieldType.SLIDER,
+          disabled: true,
         },
         {
           name: 'rating',
@@ -1522,6 +1523,18 @@ export class AppComponent implements OnInit {
           ['isOrganic', 'isOrganic', 'isOrganic'],
           ['total', 'total', 'total'],
         ],
+      },
+    });
+  }
+
+  protected updateForm() {
+    this.form.patchValue({
+      apples: 50,
+      pears: 50,
+      about: {
+        beastMode: true,
+        brightness: 100,
+        bannerColor: '#00aeff',
       },
     });
   }

--- a/src/app/signal-forms/models/signal-form.model.ts
+++ b/src/app/signal-forms/models/signal-form.model.ts
@@ -276,6 +276,14 @@ export type SignalFormFieldForKey<
 
 export type ErrorMessage<TModel> = { name: keyof TModel; message: string };
 
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object
+    ? T[K] extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : DeepPartial<T[K]>
+    : T[K];
+};
+
 export interface SignalFormContainer<TModel> {
   title?: string;
   status: WritableSignal<FormStatus>;
@@ -294,6 +302,8 @@ export interface SignalFormContainer<TModel> {
   value: Signal<TModel>;
   rawValue: Signal<TModel>;
   config: SignalFormConfig<TModel>;
+  patchValue: (partialModel: DeepPartial<TModel>) => void;
+  setValue: (model: TModel) => void;
 }
 
 export type ElementTypeForField<T extends FormFieldType> = T extends


### PR DESCRIPTION
creates methods to patch and set form values.

this means we can grab the instance created by the builder e.g.

```
this.form = FormBuilder.createForm({...config here });

this.form.patchValue({ a: true }) /* partial - will accept any part of the config, with a recursive deep-partial */
this.form.setValue({a: true, b: true, c: false }) /* wants the entire form passed in */
```